### PR TITLE
Remove double `@_exported import` in HOF playground

### DIFF
--- a/0005-higher-order-functions/Higher-Order Functions.playground/Sources/Util.swift
+++ b/0005-higher-order-functions/Higher-Order Functions.playground/Sources/Util.swift
@@ -1,5 +1,3 @@
-@_exported import Foundation
-
 // NB: `@_exported` will make foundation available in our playgrounds
 @_exported import Foundation
 


### PR DESCRIPTION
Remove double `@_exported import` in HOF playground, as it doesn't seem to be needed.

Love the project, keep it up.