### PR TITLE
Fixed Decodable implementation of Tagged type

### DIFF
--- a/0012-tagged/Tagged.playground/Pages/01-Episode.xcplaygroundpage/Contents.swift
+++ b/0012-tagged/Tagged.playground/Pages/01-Episode.xcplaygroundpage/Contents.swift
@@ -29,8 +29,7 @@ struct Tagged<Tag, RawValue> {
 
 extension Tagged: Decodable where RawValue: Decodable {
   init(from decoder: Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    self.init(rawValue: try container.decode(RawValue.self))
+    self.init(rawValue: try .init(from: decoder))
   }
 }
 


### PR DESCRIPTION
Hi guys, thanks for the Tagged episode.

I'd like to fix current implementation of Decodable, because it doesn't pass next test:
```
  func test_TaggedWithOptionalRawTypeAndNilValueDecodesCorrectly() {
    struct Container: Decodable {
      typealias Idenitifer = Tagged<Container, String?>
      let id: Idenitifer
    }

    XCTAssertNoThrow(try {
      let data = "[{\"id\":null}]".data(using: .utf8)!
      let containers = try JSONDecoder().decode([Container].self, from: data)
      XCTAssertEqual(containers.count, 1)
      XCTAssertEqual(containers.first?.id.rawValue, nil)
    }())
  }
```
For now it fails with error:
```
XCTAssertNoThrow failed: threw error "valueNotFound(Swift.Optional<Swift.String>, Swift.DecodingError.Context(codingPath: [_JSONKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "id", intValue: nil)], debugDescription: "Expected Optional<String> but found null value instead.", underlyingError: nil))" 
```

So I propose more straightforward approach of implementing Decodable by initializing RawValue from decoder.