### PR TITLE
Merge Effects instead of using array as return value

### DIFF
--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitecture/ComposableArchitecture.h
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitecture/ComposableArchitecture.h
@@ -1,0 +1,19 @@
+//
+//  ComposableArchitecture.h
+//  ComposableArchitecture
+//
+//  Created by Stephen Celis on 9/8/19.
+//  Copyright © 2019 Point-Free. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for ComposableArchitecture.
+FOUNDATION_EXPORT double ComposableArchitectureVersionNumber;
+
+//! Project version string for ComposableArchitecture.
+FOUNDATION_EXPORT const unsigned char ComposableArchitectureVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <ComposableArchitecture/PublicHeader.h>
+
+

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitecture/ComposableArchitecture.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitecture/ComposableArchitecture.swift
@@ -1,0 +1,130 @@
+import Combine
+import SwiftUI
+
+public struct Effect<Output>: Publisher {
+  public typealias Failure = Never
+
+  let publisher: AnyPublisher<Output, Failure>
+
+  public func receive<S>(
+    subscriber: S
+  ) where S: Subscriber, Failure == S.Failure, Output == S.Input {
+    self.publisher.receive(subscriber: subscriber)
+  }
+}
+
+extension Effect {
+  public static func fireAndForget(work: @escaping () -> Void) -> Effect {
+    return Deferred { () -> Empty<Output, Never> in
+      work()
+      return Empty(completeImmediately: true)
+    }.eraseToEffect()
+  }
+
+  public static func sync(work: @escaping () -> Output) -> Effect {
+    return Deferred {
+      Just(work())
+    }.eraseToEffect()
+  }
+}
+
+extension Publisher where Failure == Never {
+  public func eraseToEffect() -> Effect<Output> {
+    return Effect(publisher: self.eraseToAnyPublisher())
+  }
+}
+
+public typealias Reducer<Value, Action> = (inout Value, Action) -> [Effect<Action>]
+
+public final class Store<Value, Action>: ObservableObject {
+  private let reducer: Reducer<Value, Action>
+  @Published public private(set) var value: Value
+  private var viewCancellable: Cancellable?
+  private var effectCancellables: Set<AnyCancellable> = []
+
+  public init(initialValue: Value, reducer: @escaping Reducer<Value, Action>) {
+    self.reducer = reducer
+    self.value = initialValue
+  }
+
+  public func send(_ action: Action) {
+    let effects = self.reducer(&self.value, action)
+    effects.forEach { effect in
+      var effectCancellable: AnyCancellable?
+      var didComplete = false
+      effectCancellable = effect.sink(
+        receiveCompletion: { [weak self] _ in
+          didComplete = true
+          guard let effectCancellable = effectCancellable else { return }
+          self?.effectCancellables.remove(effectCancellable)
+      },
+        receiveValue: self.send
+      )
+      if !didComplete, let effectCancellable = effectCancellable {
+        self.effectCancellables.insert(effectCancellable)
+      }
+    }
+  }
+
+  public func view<LocalValue, LocalAction>(
+    value toLocalValue: @escaping (Value) -> LocalValue,
+    action toGlobalAction: @escaping (LocalAction) -> Action
+  ) -> Store<LocalValue, LocalAction> {
+    let localStore = Store<LocalValue, LocalAction>(
+      initialValue: toLocalValue(self.value),
+      reducer: { localValue, localAction in
+        self.send(toGlobalAction(localAction))
+        localValue = toLocalValue(self.value)
+        return []
+    }
+    )
+    localStore.viewCancellable = self.$value.sink { [weak localStore] newValue in
+      localStore?.value = toLocalValue(newValue)
+    }
+    return localStore
+  }
+}
+
+public func combine<Value, Action>(
+  _ reducers: Reducer<Value, Action>...
+) -> Reducer<Value, Action> {
+  return { value, action in
+    let effects = reducers.flatMap { $0(&value, action) }
+    return effects
+  }
+}
+
+public func pullback<LocalValue, GlobalValue, LocalAction, GlobalAction>(
+  _ reducer: @escaping Reducer<LocalValue, LocalAction>,
+  value: WritableKeyPath<GlobalValue, LocalValue>,
+  action: WritableKeyPath<GlobalAction, LocalAction?>
+) -> Reducer<GlobalValue, GlobalAction> {
+  return { globalValue, globalAction in
+    guard let localAction = globalAction[keyPath: action] else { return [] }
+    let localEffects = reducer(&globalValue[keyPath: value], localAction)
+
+    return localEffects.map { localEffect in
+      localEffect.map { localAction -> GlobalAction in
+        var globalAction = globalAction
+        globalAction[keyPath: action] = localAction
+        return globalAction
+      }
+      .eraseToEffect()
+    }
+  }
+}
+
+public func logging<Value, Action>(
+  _ reducer: @escaping Reducer<Value, Action>
+) -> Reducer<Value, Action> {
+  return { value, action in
+    let effects = reducer(&value, action)
+    let newValue = value
+    return [.fireAndForget {
+      print("Action: \(action)")
+      print("Value:")
+      dump(newValue)
+      print("---")
+      }] + effects
+  }
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitecture/ComposableArchitecture.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitecture/ComposableArchitecture.swift
@@ -28,6 +28,13 @@ extension Effect {
   }
 }
 
+public extension Effect {
+  static func emptyEffect(completeImmediately: Bool = true) -> Effect {
+    return Empty<Output, Never>(completeImmediately: completeImmediately).eraseToEffect()
+  }
+}
+
+
 extension Publisher where Failure == Never {
   public func eraseToEffect() -> Effect<Output> {
     return Effect(publisher: self.eraseToAnyPublisher())

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitecture/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitecture/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitectureTests/ComposableArchitectureTests.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitectureTests/ComposableArchitectureTests.swift
@@ -1,0 +1,33 @@
+//
+//  ComposableArchitectureTests.swift
+//  ComposableArchitectureTests
+//
+//  Copyright © 2019 Point-Free. All rights reserved.
+//
+
+import XCTest
+@testable import ComposableArchitecture
+
+class ComposableArchitectureTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitectureTests/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/ComposableArchitectureTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/Counter.h
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/Counter.h
@@ -1,0 +1,19 @@
+//
+//  Counter.h
+//  Counter
+//
+//  Created by Stephen Celis on 9/8/19.
+//  Copyright © 2019 Point-Free. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for Counter.
+FOUNDATION_EXPORT double CounterVersionNumber;
+
+//! Project version string for Counter.
+FOUNDATION_EXPORT const unsigned char CounterVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <Counter/PublicHeader.h>
+
+

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/Counter.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/Counter.swift
@@ -1,0 +1,185 @@
+import ComposableArchitecture
+import PrimeModal
+import SwiftUI
+
+public enum CounterAction: Equatable {
+  case decrTapped
+  case incrTapped
+  case nthPrimeButtonTapped
+  case nthPrimeResponse(Int?)
+  case alertDismissButtonTapped
+}
+
+public typealias CounterState = (
+  alertNthPrime: PrimeAlert?,
+  count: Int,
+  isNthPrimeButtonDisabled: Bool
+)
+
+public func counterReducer(state: inout CounterState, action: CounterAction) -> [Effect<CounterAction>] {
+  switch action {
+  case .decrTapped:
+    state.count -= 1
+    return []
+
+  case .incrTapped:
+    state.count += 1
+    return []
+
+  case .nthPrimeButtonTapped:
+    state.isNthPrimeButtonDisabled = true
+    return [
+//      nthPrime(state.count)
+      Current.nthPrime(state.count)
+        .map(CounterAction.nthPrimeResponse)
+        .receive(on: DispatchQueue.main)
+        .eraseToEffect()
+  ]
+
+  case let .nthPrimeResponse(prime):
+    state.alertNthPrime = prime.map(PrimeAlert.init(prime:))
+    state.isNthPrimeButtonDisabled = false
+    return []
+
+  case .alertDismissButtonTapped:
+    state.alertNthPrime = nil
+    return []
+  }
+}
+
+struct CounterEnvironment {
+  var nthPrime: (Int) -> Effect<Int?>
+}
+
+extension CounterEnvironment {
+  static let live = CounterEnvironment(nthPrime: Counter.nthPrime)
+}
+
+var Current = CounterEnvironment.live
+
+extension CounterEnvironment {
+  static let mock = CounterEnvironment(nthPrime: { _ in .sync { 17 }})
+}
+
+public let counterViewReducer = combine(
+  pullback(counterReducer, value: \CounterViewState.counter, action: \CounterViewAction.counter),
+  pullback(primeModalReducer, value: \.primeModal, action: \.primeModal)
+)
+
+public struct PrimeAlert: Equatable, Identifiable {
+  let prime: Int
+  public var id: Int { self.prime }
+}
+
+public struct CounterViewState: Equatable {
+  public var alertNthPrime: PrimeAlert?
+  public var count: Int
+  public var favoritePrimes: [Int]
+  public var isNthPrimeButtonDisabled: Bool
+
+  public init(
+    alertNthPrime: PrimeAlert?,
+    count: Int,
+    favoritePrimes: [Int],
+    isNthPrimeButtonDisabled: Bool
+  ) {
+    self.alertNthPrime = alertNthPrime
+    self.count = count
+    self.favoritePrimes = favoritePrimes
+    self.isNthPrimeButtonDisabled = isNthPrimeButtonDisabled
+  }
+
+  var counter: CounterState {
+    get { (self.alertNthPrime, self.count, self.isNthPrimeButtonDisabled) }
+    set { (self.alertNthPrime, self.count, self.isNthPrimeButtonDisabled) = newValue }
+  }
+
+  var primeModal: PrimeModalState {
+    get { (self.count, self.favoritePrimes) }
+    set { (self.count, self.favoritePrimes) = newValue }
+  }
+}
+
+public enum CounterViewAction: Equatable {
+  case counter(CounterAction)
+  case primeModal(PrimeModalAction)
+
+  var counter: CounterAction? {
+    get {
+      guard case let .counter(value) = self else { return nil }
+      return value
+    }
+    set {
+      guard case .counter = self, let newValue = newValue else { return }
+      self = .counter(newValue)
+    }
+  }
+
+  var primeModal: PrimeModalAction? {
+    get {
+      guard case let .primeModal(value) = self else { return nil }
+      return value
+    }
+    set {
+      guard case .primeModal = self, let newValue = newValue else { return }
+      self = .primeModal(newValue)
+    }
+  }
+
+}
+
+public struct CounterView: View {
+  @ObservedObject var store: Store<CounterViewState, CounterViewAction>
+  @State var isPrimeModalShown = false
+
+  public init(store: Store<CounterViewState, CounterViewAction>) {
+    self.store = store
+  }
+
+  public var body: some View {
+    VStack {
+      HStack {
+        Button("-") { self.store.send(.counter(.decrTapped)) }
+        Text("\(self.store.value.count)")
+        Button("+") { self.store.send(.counter(.incrTapped)) }
+      }
+      Button("Is this prime?") { self.isPrimeModalShown = true }
+      Button(
+        "What is the \(ordinal(self.store.value.count)) prime?",
+        action: self.nthPrimeButtonAction
+      )
+        .disabled(self.store.value.isNthPrimeButtonDisabled)
+    }
+    .font(.title)
+    .navigationBarTitle("Counter demo")
+    .sheet(isPresented: self.$isPrimeModalShown) {
+      IsPrimeModalView(
+        store: self.store
+          .view(
+            value: { ($0.count, $0.favoritePrimes) },
+            action: { .primeModal($0) }
+        )
+      )
+    }
+    .alert(
+      item: .constant(self.store.value.alertNthPrime)
+    ) { alert in
+      Alert(
+        title: Text("The \(ordinal(self.store.value.count)) prime is \(alert.prime)"),
+        dismissButton: .default(Text("Ok")) {
+          self.store.send(.counter(.alertDismissButtonTapped))
+        }
+      )
+    }
+  }
+
+  func nthPrimeButtonAction() {
+    self.store.send(.counter(.nthPrimeButtonTapped))
+  }
+}
+
+func ordinal(_ n: Int) -> String {
+  let formatter = NumberFormatter()
+  formatter.numberStyle = .ordinal
+  return formatter.string(for: n) ?? ""
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/Counter.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/Counter.swift
@@ -16,34 +16,31 @@ public typealias CounterState = (
   isNthPrimeButtonDisabled: Bool
 )
 
-public func counterReducer(state: inout CounterState, action: CounterAction) -> [Effect<CounterAction>] {
+public func counterReducer(state: inout CounterState, action: CounterAction) -> Effect<CounterAction> {
   switch action {
   case .decrTapped:
     state.count -= 1
-    return []
+    return .emptyEffect()
 
   case .incrTapped:
     state.count += 1
-    return []
+    return .emptyEffect()
 
   case .nthPrimeButtonTapped:
     state.isNthPrimeButtonDisabled = true
-    return [
-//      nthPrime(state.count)
-      Current.nthPrime(state.count)
-        .map(CounterAction.nthPrimeResponse)
-        .receive(on: DispatchQueue.main)
-        .eraseToEffect()
-  ]
+    return Current.nthPrime(state.count)
+      .map(CounterAction.nthPrimeResponse)
+      .receive(on: DispatchQueue.main)
+      .eraseToEffect()
 
   case let .nthPrimeResponse(prime):
     state.alertNthPrime = prime.map(PrimeAlert.init(prime:))
     state.isNthPrimeButtonDisabled = false
-    return []
+    return .emptyEffect()
 
   case .alertDismissButtonTapped:
     state.alertNthPrime = nil
-    return []
+    return .emptyEffect()
   }
 }
 

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/WolframAlpha.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/Counter/WolframAlpha.swift
@@ -1,0 +1,55 @@
+import Combine
+import ComposableArchitecture
+import Foundation
+
+private let wolframAlphaApiKey = "6H69Q3-828TKQJ4EP"
+
+struct WolframAlphaResult: Decodable {
+  let queryresult: QueryResult
+
+  struct QueryResult: Decodable {
+    let pods: [Pod]
+
+    struct Pod: Decodable {
+      let primary: Bool?
+      let subpods: [SubPod]
+
+      struct SubPod: Decodable {
+        let plaintext: String
+      }
+    }
+  }
+}
+
+func nthPrime(_ n: Int) -> Effect<Int?> {
+  return wolframAlpha(query: "prime \(n)").map { result in
+    result
+      .flatMap {
+        $0.queryresult
+          .pods
+          .first(where: { $0.primary == .some(true) })?
+          .subpods
+          .first?
+          .plaintext
+    }
+    .flatMap(Int.init)
+  }
+  .eraseToEffect()
+}
+
+func wolframAlpha(query: String) -> Effect<WolframAlphaResult?> {
+  var components = URLComponents(string: "https://api.wolframalpha.com/v2/query")!
+  components.queryItems = [
+    URLQueryItem(name: "input", value: query),
+    URLQueryItem(name: "format", value: "plaintext"),
+    URLQueryItem(name: "output", value: "JSON"),
+    URLQueryItem(name: "appid", value: wolframAlphaApiKey),
+  ]
+
+  return URLSession.shared
+    .dataTaskPublisher(for: components.url(relativeTo: nil)!)
+    .map { data, _ in data }
+    .decode(type: WolframAlphaResult?.self, decoder: JSONDecoder())
+    .replaceError(with: nil)
+    .eraseToEffect()
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/CounterTests/CounterTests.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/CounterTests/CounterTests.swift
@@ -1,0 +1,203 @@
+import XCTest
+@testable import Counter
+
+class CounterTests: XCTestCase {
+  override class func setUp() {
+    super.setUp()
+    Current = .mock
+  }
+
+  func testIncrButtonTapped() {
+    var state = CounterViewState(
+      alertNthPrime: nil,
+      count: 2,
+      favoritePrimes: [3, 5],
+      isNthPrimeButtonDisabled: false
+    )
+    let effects = counterViewReducer(&state, .counter(.incrTapped))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 3,
+        favoritePrimes: [3, 5],
+        isNthPrimeButtonDisabled: false
+      )
+    )
+    XCTAssertTrue(effects.isEmpty)
+  }
+
+  func testDecrButtonTapped() {
+    var state = CounterViewState(
+      alertNthPrime: nil,
+      count: 2,
+      favoritePrimes: [3, 5],
+      isNthPrimeButtonDisabled: false
+    )
+    let effects = counterViewReducer(&state, .counter(.decrTapped))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 1,
+        favoritePrimes: [3, 5],
+        isNthPrimeButtonDisabled: false
+      )
+    )
+    XCTAssertTrue(effects.isEmpty)
+  }
+
+  func testNthPrimeButtonHappyFlow() {
+    Current.nthPrime = { _ in .sync { 17 } }
+
+    var state = CounterViewState(
+      alertNthPrime: nil,
+      count: 2,
+      favoritePrimes: [3, 5],
+      isNthPrimeButtonDisabled: false
+    )
+
+    var effects = counterViewReducer(&state, .counter(.nthPrimeButtonTapped))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 2,
+        favoritePrimes: [3, 5],
+        isNthPrimeButtonDisabled: true
+      )
+    )
+    XCTAssertEqual(effects.count, 1)
+
+    var nextAction: CounterViewAction!
+    let receivedCompletion = self.expectation(description: "receivedCompletion")
+    effects[0].sink(
+      receiveCompletion: { _ in
+        receivedCompletion.fulfill()
+    },
+      receiveValue: { action in
+        XCTAssertEqual(action, .counter(.nthPrimeResponse(17)))
+        nextAction = action
+    }
+    )
+    self.wait(for: [receivedCompletion], timeout: 0.01)
+
+    effects = counterViewReducer(&state, nextAction)
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: PrimeAlert(prime: 17),
+        count: 2,
+        favoritePrimes: [3, 5],
+        isNthPrimeButtonDisabled: false
+      )
+    )
+    XCTAssertTrue(effects.isEmpty)
+
+    effects = counterViewReducer(&state, .counter(.alertDismissButtonTapped))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 2,
+        favoritePrimes: [3, 5],
+        isNthPrimeButtonDisabled: false
+      )
+    )
+    XCTAssertTrue(effects.isEmpty)
+  }
+
+  func testNthPrimeButtonUnhappyFlow() {
+    Current.nthPrime = { _ in .sync { nil } }
+
+    var state = CounterViewState(
+      alertNthPrime: nil,
+      count: 2,
+      favoritePrimes: [3, 5],
+      isNthPrimeButtonDisabled: false
+    )
+
+    var effects = counterViewReducer(&state, .counter(.nthPrimeButtonTapped))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 2,
+        favoritePrimes: [3, 5],
+        isNthPrimeButtonDisabled: true
+      )
+    )
+    XCTAssertEqual(effects.count, 1)
+
+
+    var nextAction: CounterViewAction!
+    let receivedCompletion = self.expectation(description: "receivedCompletion")
+    effects[0].sink(
+      receiveCompletion: { _ in
+        receivedCompletion.fulfill()
+    },
+      receiveValue: { action in
+        XCTAssertEqual(action, .counter(.nthPrimeResponse(nil)))
+        nextAction = action
+    }
+    )
+    self.wait(for: [receivedCompletion], timeout: 0.01)
+
+    effects = counterViewReducer(&state, nextAction)
+
+//    effects = counterViewReducer(&state, .counter(.nthPrimeResponse(nil)))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 2,
+        favoritePrimes: [3, 5],
+        isNthPrimeButtonDisabled: false
+      )
+    )
+    XCTAssertTrue(effects.isEmpty)
+  }
+
+  func testPrimeModal() {
+    var state = CounterViewState(
+      alertNthPrime: nil,
+      count: 2,
+      favoritePrimes: [3, 5],
+      isNthPrimeButtonDisabled: false
+    )
+
+    var effects = counterViewReducer(&state, .primeModal(.saveFavoritePrimeTapped))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 2,
+        favoritePrimes: [3, 5, 2],
+        isNthPrimeButtonDisabled: false
+      )
+    )
+    XCTAssert(effects.isEmpty)
+
+    effects = counterViewReducer(&state, .primeModal(.removeFavoritePrimeTapped))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 2,
+        favoritePrimes: [3, 5],
+        isNthPrimeButtonDisabled: false
+      )
+    )
+    XCTAssert(effects.isEmpty)
+  }
+
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/CounterTests/CounterTests.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/CounterTests/CounterTests.swift
@@ -25,7 +25,7 @@ class CounterTests: XCTestCase {
         isNthPrimeButtonDisabled: false
       )
     )
-    XCTAssertTrue(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
   }
 
   func testDecrButtonTapped() {
@@ -46,7 +46,7 @@ class CounterTests: XCTestCase {
         isNthPrimeButtonDisabled: false
       )
     )
-    XCTAssertTrue(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
   }
 
   func testNthPrimeButtonHappyFlow() {
@@ -70,11 +70,11 @@ class CounterTests: XCTestCase {
         isNthPrimeButtonDisabled: true
       )
     )
-    XCTAssertEqual(effects.count, 1)
+//    XCTAssertEqual(effects.count, 1)
 
     var nextAction: CounterViewAction!
     let receivedCompletion = self.expectation(description: "receivedCompletion")
-    effects[0].sink(
+    effects.sink(
       receiveCompletion: { _ in
         receivedCompletion.fulfill()
     },
@@ -96,7 +96,7 @@ class CounterTests: XCTestCase {
         isNthPrimeButtonDisabled: false
       )
     )
-    XCTAssertTrue(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
 
     effects = counterViewReducer(&state, .counter(.alertDismissButtonTapped))
 
@@ -109,7 +109,7 @@ class CounterTests: XCTestCase {
         isNthPrimeButtonDisabled: false
       )
     )
-    XCTAssertTrue(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
   }
 
   func testNthPrimeButtonUnhappyFlow() {
@@ -133,12 +133,12 @@ class CounterTests: XCTestCase {
         isNthPrimeButtonDisabled: true
       )
     )
-    XCTAssertEqual(effects.count, 1)
+//    XCTAssertEqual(effects.count, 1)
 
 
     var nextAction: CounterViewAction!
     let receivedCompletion = self.expectation(description: "receivedCompletion")
-    effects[0].sink(
+    effects.sink(
       receiveCompletion: { _ in
         receivedCompletion.fulfill()
     },
@@ -162,7 +162,7 @@ class CounterTests: XCTestCase {
         isNthPrimeButtonDisabled: false
       )
     )
-    XCTAssertTrue(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
   }
 
   func testPrimeModal() {
@@ -184,7 +184,7 @@ class CounterTests: XCTestCase {
         isNthPrimeButtonDisabled: false
       )
     )
-    XCTAssert(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
 
     effects = counterViewReducer(&state, .primeModal(.removeFavoritePrimeTapped))
 
@@ -197,7 +197,7 @@ class CounterTests: XCTestCase {
         isNthPrimeButtonDisabled: false
       )
     )
-    XCTAssert(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
   }
 
 }

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/CounterTests/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/CounterTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimes/FavoritePrimes.h
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimes/FavoritePrimes.h
@@ -1,0 +1,19 @@
+//
+//  FavoritePrimes.h
+//  FavoritePrimes
+//
+//  Created by Stephen Celis on 9/8/19.
+//  Copyright © 2019 Point-Free. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for FavoritePrimes.
+FOUNDATION_EXPORT double FavoritePrimesVersionNumber;
+
+//! Project version string for FavoritePrimes.
+FOUNDATION_EXPORT const unsigned char FavoritePrimesVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <FavoritePrimes/PublicHeader.h>
+
+

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimes/FavoritePrimes.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimes/FavoritePrimes.swift
@@ -1,0 +1,189 @@
+import ComposableArchitecture
+import SwiftUI
+
+public enum FavoritePrimesAction: Equatable {
+  case deleteFavoritePrimes(IndexSet)
+  case loadButtonTapped
+  case loadedFavoritePrimes([Int])
+  case saveButtonTapped
+}
+
+public func favoritePrimesReducer(state: inout [Int], action: FavoritePrimesAction) -> [Effect<FavoritePrimesAction>] {
+  switch action {
+  case let .deleteFavoritePrimes(indexSet):
+    for index in indexSet {
+      state.remove(at: index)
+    }
+    return [
+    ]
+
+  case let .loadedFavoritePrimes(favoritePrimes):
+    state = favoritePrimes
+    return []
+
+  case .saveButtonTapped:
+    return [
+      Current.fileClient.save("favorite-primes.json", try! JSONEncoder().encode(state))
+        .fireAndForget()
+//      saveEffect(favoritePrimes: state)
+    ]
+
+  case .loadButtonTapped:
+    return [
+      Current.fileClient.load("favorite-primes.json")
+        .compactMap { $0 }
+        .decode(type: [Int].self, decoder: JSONDecoder())
+        .catch { error in Empty(completeImmediately: true) }
+        .map(FavoritePrimesAction.loadedFavoritePrimes)
+//        .merge(with: Just(FavoritePrimesAction.loadedFavoritePrimes([2, 31])))
+        .eraseToEffect()
+//      loadEffect
+//        .compactMap { $0 }
+//        .eraseToEffect()
+    ]
+  }
+}
+
+// (Never) -> A
+
+import Combine
+
+extension Publisher where Output == Never, Failure == Never {
+  func fireAndForget<A>() -> Effect<A> {
+    return self.map(absurd).eraseToEffect()
+  }
+}
+
+
+func absurd<A>(_ never: Never) -> A {}
+
+
+struct FileClient {
+  var load: (String) -> Effect<Data?>
+  var save: (String, Data) -> Effect<Never>
+}
+extension FileClient {
+  static let live = FileClient(
+    load: { fileName -> Effect<Data?> in
+      .sync {
+        let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+        let documentsUrl = URL(fileURLWithPath: documentsPath)
+        let favoritePrimesUrl = documentsUrl.appendingPathComponent(fileName)
+        return try? Data(contentsOf: favoritePrimesUrl)
+      }
+  },
+    save: { fileName, data in
+      return .fireAndForget {
+        let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+        let documentsUrl = URL(fileURLWithPath: documentsPath)
+        let favoritePrimesUrl = documentsUrl.appendingPathComponent(fileName)
+        try! data.write(to: favoritePrimesUrl)
+      }
+  }
+  )
+}
+
+struct FavoritePrimesEnvironment {
+  var fileClient: FileClient
+}
+extension FavoritePrimesEnvironment {
+  static let live = FavoritePrimesEnvironment(fileClient: .live)
+}
+
+var Current = FavoritePrimesEnvironment.live
+
+#if DEBUG
+extension FavoritePrimesEnvironment {
+  static let mock = FavoritePrimesEnvironment(
+    fileClient: FileClient(
+      load: { _ in Effect<Data?>.sync {
+        try! JSONEncoder().encode([2, 31])
+        } },
+      save: { _, _ in .fireAndForget {} }
+    )
+  )
+}
+#endif
+
+//struct Environment {
+//  var date: () -> Date
+//}
+//extension Environment {
+//  static let live = Environment(date: Date.init)
+//}
+//
+//extension Environment {
+//  static let mock = Environment(date: { Date.init(timeIntervalSince1970: 1234567890) })
+//}
+//
+////Current = .mock
+//
+//struct GitHubClient {
+//  var fetchRepos: (@escaping (Result<[Repo], Error>) -> Void) -> Void
+//
+//  struct Repo: Decodable {
+//    var archived: Bool
+//    var description: String?
+//    var htmlUrl: URL
+//    var name: String
+//    var pushedAt: Date?
+//  }
+//}
+//
+//#if DEBUG
+//var Current = Environment.live
+//#else
+//let Current = Environment.live
+//#endif
+
+//private func saveEffect(favoritePrimes: [Int]) -> Effect<FavoritePrimesAction> {
+//  return .fireAndForget {
+////    Current.date()
+//    let data = try! JSONEncoder().encode(favoritePrimes)
+//    let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+//    let documentsUrl = URL(fileURLWithPath: documentsPath)
+//    let favoritePrimesUrl = documentsUrl.appendingPathComponent("favorite-primes.json")
+//    try! data.write(to: favoritePrimesUrl)
+//  }
+//}
+
+//private let loadEffect = Effect<FavoritePrimesAction?>.sync {
+//  let documentsPath = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
+//  let documentsUrl = URL(fileURLWithPath: documentsPath)
+//  let favoritePrimesUrl = documentsUrl.appendingPathComponent("favorite-primes.json")
+//  guard
+//    let data = try? Data(contentsOf: favoritePrimesUrl),
+//    let favoritePrimes = try? JSONDecoder().decode([Int].self, from: data)
+//    else { return nil }
+//  return .loadedFavoritePrimes(favoritePrimes)
+//}
+
+public struct FavoritePrimesView: View {
+  @ObservedObject var store: Store<[Int], FavoritePrimesAction>
+
+  public init(store: Store<[Int], FavoritePrimesAction>) {
+    self.store = store
+  }
+
+  public var body: some View {
+    List {
+      ForEach(self.store.value, id: \.self) { prime in
+        Text("\(prime)")
+      }
+      .onDelete { indexSet in
+        self.store.send(.deleteFavoritePrimes(indexSet))
+      }
+    }
+    .navigationBarTitle("Favorite primes")
+    .navigationBarItems(
+      trailing: HStack {
+        Button("Save") {
+          self.store.send(.saveButtonTapped)
+        }
+        Button("Load") {
+          self.store.send(.loadButtonTapped)
+        }
+      }
+    )
+  }
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimes/FavoritePrimes.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimes/FavoritePrimes.swift
@@ -8,39 +8,30 @@ public enum FavoritePrimesAction: Equatable {
   case saveButtonTapped
 }
 
-public func favoritePrimesReducer(state: inout [Int], action: FavoritePrimesAction) -> [Effect<FavoritePrimesAction>] {
+public func favoritePrimesReducer(state: inout [Int], action: FavoritePrimesAction) -> Effect<FavoritePrimesAction> {
   switch action {
   case let .deleteFavoritePrimes(indexSet):
     for index in indexSet {
       state.remove(at: index)
     }
-    return [
-    ]
-
+    return .emptyEffect()
+    
   case let .loadedFavoritePrimes(favoritePrimes):
     state = favoritePrimes
-    return []
-
+    return .emptyEffect()
+    
   case .saveButtonTapped:
-    return [
+    return
       Current.fileClient.save("favorite-primes.json", try! JSONEncoder().encode(state))
         .fireAndForget()
-//      saveEffect(favoritePrimes: state)
-    ]
-
+    
   case .loadButtonTapped:
-    return [
-      Current.fileClient.load("favorite-primes.json")
-        .compactMap { $0 }
-        .decode(type: [Int].self, decoder: JSONDecoder())
-        .catch { error in Empty(completeImmediately: true) }
-        .map(FavoritePrimesAction.loadedFavoritePrimes)
-//        .merge(with: Just(FavoritePrimesAction.loadedFavoritePrimes([2, 31])))
-        .eraseToEffect()
-//      loadEffect
-//        .compactMap { $0 }
-//        .eraseToEffect()
-    ]
+    return Current.fileClient.load("favorite-primes.json")
+      .compactMap { $0 }
+      .decode(type: [Int].self, decoder: JSONDecoder())
+      .catch { error in Empty(completeImmediately: true) }
+      .map(FavoritePrimesAction.loadedFavoritePrimes)
+      .eraseToEffect()
   }
 }
 

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimes/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimes/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimesTests/FavoritePrimesTests.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimesTests/FavoritePrimesTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import FavoritePrimes
+
+class FavoritePrimesTests: XCTestCase {
+  override class func setUp() {
+    super.setUp()
+    Current = .mock
+  }
+
+  func testDeleteFavoritePrimes() {
+    var state = [2, 3, 5, 7]
+    let effects = favoritePrimesReducer(state: &state, action: .deleteFavoritePrimes([2]))
+
+    XCTAssertEqual(state, [2, 3, 7])
+    XCTAssert(effects.isEmpty)
+  }
+
+  func testSaveButtonTapped() {
+    var didSave = false
+    Current.fileClient.save = { _, data in
+      .fireAndForget {
+        didSave = true
+      }
+    }
+
+    var state = [2, 3, 5, 7]
+    let effects = favoritePrimesReducer(state: &state, action: .saveButtonTapped)
+
+    XCTAssertEqual(state, [2, 3, 5, 7])
+    XCTAssertEqual(effects.count, 1)
+
+    effects[0].sink { _ in XCTFail() }
+
+    XCTAssert(didSave)
+  }
+
+  func testLoadFavoritePrimesFlow() {
+    Current.fileClient.load = { _ in .sync { try! JSONEncoder().encode([2, 31]) } }
+
+    var state = [2, 3, 5, 7]
+    var effects = favoritePrimesReducer(state: &state, action: .loadButtonTapped)
+
+    XCTAssertEqual(state, [2, 3, 5, 7])
+    XCTAssertEqual(effects.count, 1)
+
+    var nextAction: FavoritePrimesAction!
+    let receivedCompletion = self.expectation(description: "receivedCompletion")
+    effects[0].sink(
+      receiveCompletion: { _ in
+        receivedCompletion.fulfill()
+    },
+      receiveValue: { action in
+        XCTAssertEqual(action, .loadedFavoritePrimes([2, 31]))
+        nextAction = action
+    })
+    self.wait(for: [receivedCompletion], timeout: 0)
+
+    effects = favoritePrimesReducer(state: &state, action: nextAction)
+
+    XCTAssertEqual(state, [2, 31])
+    XCTAssert(effects.isEmpty)
+  }
+
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimesTests/FavoritePrimesTests.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimesTests/FavoritePrimesTests.swift
@@ -12,7 +12,7 @@ class FavoritePrimesTests: XCTestCase {
     let effects = favoritePrimesReducer(state: &state, action: .deleteFavoritePrimes([2]))
 
     XCTAssertEqual(state, [2, 3, 7])
-    XCTAssert(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
   }
 
   func testSaveButtonTapped() {
@@ -27,9 +27,9 @@ class FavoritePrimesTests: XCTestCase {
     let effects = favoritePrimesReducer(state: &state, action: .saveButtonTapped)
 
     XCTAssertEqual(state, [2, 3, 5, 7])
-    XCTAssertEqual(effects.count, 1)
+//    XCTAssertEqual(effects.count, 1)
 
-    effects[0].sink { _ in XCTFail() }
+    effects.sink { _ in XCTFail() }
 
     XCTAssert(didSave)
   }
@@ -41,11 +41,11 @@ class FavoritePrimesTests: XCTestCase {
     var effects = favoritePrimesReducer(state: &state, action: .loadButtonTapped)
 
     XCTAssertEqual(state, [2, 3, 5, 7])
-    XCTAssertEqual(effects.count, 1)
+//    XCTAssertEqual(effects.count, 1)
 
     var nextAction: FavoritePrimesAction!
     let receivedCompletion = self.expectation(description: "receivedCompletion")
-    effects[0].sink(
+    effects.sink(
       receiveCompletion: { _ in
         receivedCompletion.fulfill()
     },
@@ -58,7 +58,7 @@ class FavoritePrimesTests: XCTestCase {
     effects = favoritePrimesReducer(state: &state, action: nextAction)
 
     XCTAssertEqual(state, [2, 31])
-    XCTAssert(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
   }
 
 }

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimesTests/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/FavoritePrimesTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/Package.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/Package.swift
@@ -1,0 +1,9 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+  name: "ComposableArchitecture",
+  dependencies: [
+    .package(url: "https://github.com/pointfreeco/swift-enum-properties.git", from: "0.1.0")
+  ]
+)

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModal/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModal/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModal/PrimeModal.h
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModal/PrimeModal.h
@@ -1,0 +1,19 @@
+//
+//  PrimeModal.h
+//  PrimeModal
+//
+//  Created by Stephen Celis on 9/8/19.
+//  Copyright © 2019 Point-Free. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for PrimeModal.
+FOUNDATION_EXPORT double PrimeModalVersionNumber;
+
+//! Project version string for PrimeModal.
+FOUNDATION_EXPORT const unsigned char PrimeModalVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <PrimeModal/PublicHeader.h>
+
+

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModal/PrimeModal.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModal/PrimeModal.swift
@@ -1,0 +1,57 @@
+import ComposableArchitecture
+import SwiftUI
+
+public typealias PrimeModalState = (count: Int, favoritePrimes: [Int])
+
+public enum PrimeModalAction: Equatable {
+  case saveFavoritePrimeTapped
+  case removeFavoritePrimeTapped
+}
+
+public func primeModalReducer(state: inout PrimeModalState, action: PrimeModalAction) -> [Effect<PrimeModalAction>] {
+  switch action {
+  case .removeFavoritePrimeTapped:
+    state.favoritePrimes.removeAll(where: { $0 == state.count })
+    return []
+
+  case .saveFavoritePrimeTapped:
+    state.favoritePrimes.append(state.count)
+    return []
+  }
+}
+
+public struct IsPrimeModalView: View {
+  @ObservedObject var store: Store<PrimeModalState, PrimeModalAction>
+
+  public init(store: Store<PrimeModalState, PrimeModalAction>) {
+    self.store = store
+  }
+
+  public var body: some View {
+    VStack {
+      if isPrime(self.store.value.count) {
+        Text("\(self.store.value.count) is prime 🎉")
+        if self.store.value.favoritePrimes.contains(self.store.value.count) {
+          Button("Remove from favorite primes") {
+            self.store.send(.removeFavoritePrimeTapped)
+          }
+        } else {
+          Button("Save to favorite primes") {
+            self.store.send(.saveFavoritePrimeTapped)
+          }
+        }
+      } else {
+        Text("\(self.store.value.count) is not prime :(")
+      }
+    }
+  }
+}
+
+func isPrime(_ p: Int) -> Bool {
+  if p <= 1 { return false }
+  if p <= 3 { return true }
+  for i in 2...Int(sqrtf(Float(p))) {
+    if p % i == 0 { return false }
+  }
+  return true
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModal/PrimeModal.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModal/PrimeModal.swift
@@ -8,15 +8,15 @@ public enum PrimeModalAction: Equatable {
   case removeFavoritePrimeTapped
 }
 
-public func primeModalReducer(state: inout PrimeModalState, action: PrimeModalAction) -> [Effect<PrimeModalAction>] {
+public func primeModalReducer(state: inout PrimeModalState, action: PrimeModalAction) -> Effect<PrimeModalAction> {
   switch action {
   case .removeFavoritePrimeTapped:
     state.favoritePrimes.removeAll(where: { $0 == state.count })
-    return []
+    return .emptyEffect()
 
   case .saveFavoritePrimeTapped:
     state.favoritePrimes.append(state.count)
-    return []
+    return .emptyEffect()
   }
 }
 

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModalTests/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModalTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModalTests/PrimeModalTests.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModalTests/PrimeModalTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import PrimeModal
+
+class PrimeModalTests: XCTestCase {
+  func testSaveFavoritesPrimesTapped() {
+    var state = (count: 2, favoritePrimes: [3, 5])
+    let effects = primeModalReducer(state: &state, action: .saveFavoritePrimeTapped)
+
+    let (count, favoritePrimes) = state
+    XCTAssertEqual(count, 2)
+    XCTAssertEqual(favoritePrimes, [3, 5, 2])
+    XCTAssert(effects.isEmpty)
+  }
+
+  func testRemoveFavoritesPrimesTapped() {
+    var state = (count: 3, favoritePrimes: [3, 5])
+    let effects = primeModalReducer(state: &state, action: .removeFavoritePrimeTapped)
+
+    let (count, favoritePrimes) = state
+    XCTAssertEqual(count, 3)
+    XCTAssertEqual(favoritePrimes, [5])
+    XCTAssert(effects.isEmpty)
+  }
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModalTests/PrimeModalTests.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeModalTests/PrimeModalTests.swift
@@ -9,7 +9,7 @@ class PrimeModalTests: XCTestCase {
     let (count, favoritePrimes) = state
     XCTAssertEqual(count, 2)
     XCTAssertEqual(favoritePrimes, [3, 5, 2])
-    XCTAssert(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
   }
 
   func testRemoveFavoritesPrimesTapped() {
@@ -19,6 +19,6 @@ class PrimeModalTests: XCTestCase {
     let (count, favoritePrimes) = state
     XCTAssertEqual(count, 3)
     XCTAssertEqual(favoritePrimes, [5])
-    XCTAssert(effects.isEmpty)
+    effects.sink { _ in XCTFail() }
   }
 }

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Combine.xcplaygroundpage/Contents.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Combine.xcplaygroundpage/Contents.swift
@@ -1,0 +1,82 @@
+
+public struct Effect<A> {
+  public let run: (@escaping (A) -> Void) -> Void
+
+  public func map<B>(_ f: @escaping (A) -> B) -> Effect<B> {
+    return Effect<B> { callback in self.run { a in callback(f(a)) } }
+  }
+}
+
+import Dispatch
+
+let anIntInTwoSeconds = Effect<Int> { callback in
+  DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+    callback(42)
+    callback(1729)
+  }
+}
+
+anIntInTwoSeconds.run { int in print(int) }
+
+//anIntInTwoSeconds.map { $0 * $0 }.run { int in print(int) }
+
+import Combine
+
+//Publisher.init
+
+//AnyPublisher.init(<#T##publisher: Publisher##Publisher#>)
+
+
+var count = 0
+let iterator = AnyIterator<Int>.init {
+  count += 1
+  return count
+}
+Array(iterator.prefix(10))
+
+let aFutureInt = Deferred {
+  Future<Int, Never> { callback in
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+      print("Hello from the future")
+      callback(.success(42))
+      callback(.success(1729))
+    }
+  }
+}
+
+//aFutureInt.subscribe(AnySubscriber<Int, Never>.init(
+//  receiveSubscription: { subscription in
+//    print("subscription")
+//    subscription.cancel()
+//    subscription.request(.unlimited)
+//},
+//  receiveValue: { value -> Subscribers.Demand in
+//    print("value", value)
+//    return .unlimited
+//},
+//  receiveCompletion: { completion in
+//    print("completion", completion)
+//}
+//))
+
+let cancellable = aFutureInt.sink { int in
+  print(int)
+}
+//cancellable.cancel()
+
+//Subject.init
+
+let passthrough = PassthroughSubject<Int, Never>.init()
+let currentValue = CurrentValueSubject<Int, Never>.init(2)
+
+let c1 = passthrough.sink { x in
+  print("passthrough", x)
+}
+let c2 = currentValue.sink { x in
+  print("currentValue", x)
+}
+
+passthrough.send(42)
+currentValue.send(1729)
+passthrough.send(42)
+currentValue.send(1729)

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Counter.xcplaygroundpage/Contents.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Counter.xcplaygroundpage/Contents.swift
@@ -1,0 +1,21 @@
+import ComposableArchitecture
+@testable import Counter
+import PlaygroundSupport
+import SwiftUI
+
+Current = .mock
+Current.nthPrime = { _ in .sync { 7236893748932 }}
+
+PlaygroundPage.current.liveView = UIHostingController(
+  rootView: CounterView(
+    store: Store<CounterViewState, CounterViewAction>(
+      initialValue: CounterViewState(
+        alertNthPrime: nil,
+        count: 0,
+        favoritePrimes: [],
+        isNthPrimeButtonDisabled: false
+      ),
+      reducer: logging(counterViewReducer)
+    )
+  )
+)

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -1,0 +1,20 @@
+import ComposableArchitecture
+@testable import FavoritePrimes
+import PlaygroundSupport
+import SwiftUI
+
+Current = .mock
+Current.fileClient.load = { _ in
+  Effect.sync { try! JSONEncoder().encode(Array(1...1000)) }
+}
+
+PlaygroundPage.current.liveView = UIHostingController(
+  rootView: NavigationView {
+    FavoritePrimesView(
+      store: Store<[Int], FavoritePrimesAction>(
+        initialValue: [2, 3, 5, 7, 11],
+        reducer: favoritePrimesReducer
+      )
+    )
+  }
+)

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Prime Modal.xcplaygroundpage/Contents.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Prime Modal.xcplaygroundpage/Contents.swift
@@ -1,0 +1,13 @@
+import ComposableArchitecture
+import PlaygroundSupport
+import PrimeModal
+import SwiftUI
+
+PlaygroundPage.current.liveView = UIHostingController(
+  rootView: IsPrimeModalView(
+    store: Store<PrimeModalState, PrimeModalAction>(
+      initialValue: (2, [2, 3, 5]),
+      reducer: primeModalReducer
+    )
+  )
+)

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/contents.xcplayground
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/contents.xcplayground
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='6.0' target-platform='ios'>
+    <pages>
+        <page name='Counter'/>
+        <page name='Favorite Primes'/>
+        <page name='Prime Modal'/>
+        <page name='Combine'/>
+    </pages>
+</playground>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/project.pbxproj
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/project.pbxproj
@@ -1,0 +1,1689 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CAD67E2023329887000C7787 /* WolframAlpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC29217322FB231F006090DF /* WolframAlpha.swift */; };
+		DC36ED17234CD8040027F7A1 /* ComposableArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C59B2326032B008B45A0 /* ComposableArchitecture.framework */; };
+		DC90717022FA102900B38B42 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC90716F22FA102900B38B42 /* AppDelegate.swift */; };
+		DC90717222FA102900B38B42 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC90717122FA102900B38B42 /* SceneDelegate.swift */; };
+		DC90717422FA102900B38B42 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC90717322FA102900B38B42 /* ContentView.swift */; };
+		DC90717622FA102A00B38B42 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC90717522FA102A00B38B42 /* Assets.xcassets */; };
+		DC90717922FA102A00B38B42 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC90717822FA102A00B38B42 /* Preview Assets.xcassets */; };
+		DC90717C22FA102A00B38B42 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DC90717A22FA102A00B38B42 /* LaunchScreen.storyboard */; };
+		DC90718722FA102B00B38B42 /* PrimeTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC90718622FA102B00B38B42 /* PrimeTimeTests.swift */; };
+		DC90719222FA151D00B38B42 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC90719122FA151D00B38B42 /* Util.swift */; };
+		DCF0C5A42326032B008B45A0 /* ComposableArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C59B2326032B008B45A0 /* ComposableArchitecture.framework */; };
+		DCF0C5AB2326032B008B45A0 /* ComposableArchitectureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF0C5AA2326032B008B45A0 /* ComposableArchitectureTests.swift */; };
+		DCF0C5AD2326032B008B45A0 /* ComposableArchitecture.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF0C59D2326032B008B45A0 /* ComposableArchitecture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCF0C5B22326032B008B45A0 /* ComposableArchitecture.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C59B2326032B008B45A0 /* ComposableArchitecture.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DCF0C5C723260348008B45A0 /* Counter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C5BE23260348008B45A0 /* Counter.framework */; };
+		DCF0C5CE23260348008B45A0 /* CounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF0C5CD23260348008B45A0 /* CounterTests.swift */; };
+		DCF0C5D023260348008B45A0 /* Counter.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF0C5C023260348008B45A0 /* Counter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCF0C5D323260348008B45A0 /* Counter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C5BE23260348008B45A0 /* Counter.framework */; };
+		DCF0C5D423260348008B45A0 /* Counter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C5BE23260348008B45A0 /* Counter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DCF0C5E92326035C008B45A0 /* PrimeModal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C5E02326035C008B45A0 /* PrimeModal.framework */; };
+		DCF0C5F02326035C008B45A0 /* PrimeModalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF0C5EF2326035C008B45A0 /* PrimeModalTests.swift */; };
+		DCF0C5F22326035C008B45A0 /* PrimeModal.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF0C5E22326035C008B45A0 /* PrimeModal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCF0C5F62326035C008B45A0 /* PrimeModal.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C5E02326035C008B45A0 /* PrimeModal.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DCF0C60B2326036F008B45A0 /* FavoritePrimes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C6022326036F008B45A0 /* FavoritePrimes.framework */; };
+		DCF0C6122326036F008B45A0 /* FavoritePrimesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF0C6112326036F008B45A0 /* FavoritePrimesTests.swift */; };
+		DCF0C6142326036F008B45A0 /* FavoritePrimes.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF0C6042326036F008B45A0 /* FavoritePrimes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCF0C6172326036F008B45A0 /* FavoritePrimes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C6022326036F008B45A0 /* FavoritePrimes.framework */; };
+		DCF0C6182326036F008B45A0 /* FavoritePrimes.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C6022326036F008B45A0 /* FavoritePrimes.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DCF0C628232603B7008B45A0 /* ComposableArchitecture.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF0C627232603B7008B45A0 /* ComposableArchitecture.swift */; };
+		DCF0C62A23260405008B45A0 /* FavoritePrimes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF0C62923260405008B45A0 /* FavoritePrimes.swift */; };
+		DCF0C62C2326040D008B45A0 /* PrimeModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF0C62B2326040D008B45A0 /* PrimeModal.swift */; };
+		DCF0C62E23260414008B45A0 /* Counter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF0C62D23260414008B45A0 /* Counter.swift */; };
+		DCF88EFF234D4A20001BA79A /* ComposableArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C59B2326032B008B45A0 /* ComposableArchitecture.framework */; };
+		DCF88F00234D4A28001BA79A /* ComposableArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C59B2326032B008B45A0 /* ComposableArchitecture.framework */; };
+		DCF88F01234D4A28001BA79A /* PrimeModal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C5E02326035C008B45A0 /* PrimeModal.framework */; };
+		DCF88F02234D4A3B001BA79A /* ComposableArchitecture.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCF0C59B2326032B008B45A0 /* ComposableArchitecture.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CAD67E1C2332982E000C7787 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C5DF2326035C008B45A0;
+			remoteInfo = PrimeModal;
+		};
+		DC90718322FA102B00B38B42 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DC90716B22FA102900B38B42;
+			remoteInfo = PrimeTime;
+		};
+		DCF0C5A52326032B008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C59A2326032B008B45A0;
+			remoteInfo = ComposableArchitecture;
+		};
+		DCF0C5A72326032B008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DC90716B22FA102900B38B42;
+			remoteInfo = PrimeTime;
+		};
+		DCF0C5AE2326032B008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C59A2326032B008B45A0;
+			remoteInfo = ComposableArchitecture;
+		};
+		DCF0C5C823260348008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C5BD23260348008B45A0;
+			remoteInfo = Counter;
+		};
+		DCF0C5CA23260348008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DC90716B22FA102900B38B42;
+			remoteInfo = PrimeTime;
+		};
+		DCF0C5D123260348008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C5BD23260348008B45A0;
+			remoteInfo = Counter;
+		};
+		DCF0C5EA2326035C008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C5DF2326035C008B45A0;
+			remoteInfo = PrimeModal;
+		};
+		DCF0C5EC2326035C008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DC90716B22FA102900B38B42;
+			remoteInfo = PrimeTime;
+		};
+		DCF0C60C2326036F008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C6012326036F008B45A0;
+			remoteInfo = FavoritePrimes;
+		};
+		DCF0C60E2326036F008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DC90716B22FA102900B38B42;
+			remoteInfo = PrimeTime;
+		};
+		DCF0C6152326036F008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C6012326036F008B45A0;
+			remoteInfo = FavoritePrimes;
+		};
+		DCF0C61F23260383008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C59A2326032B008B45A0;
+			remoteInfo = ComposableArchitecture;
+		};
+		DCF0C62123260387008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C59A2326032B008B45A0;
+			remoteInfo = ComposableArchitecture;
+		};
+		DCF0C6232326038A008B45A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DC90716422FA102900B38B42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCF0C59A2326032B008B45A0;
+			remoteInfo = ComposableArchitecture;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		DCF0C5B12326032B008B45A0 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				DCF0C6182326036F008B45A0 /* FavoritePrimes.framework in Embed Frameworks */,
+				DCF0C5B22326032B008B45A0 /* ComposableArchitecture.framework in Embed Frameworks */,
+				DCF0C5D423260348008B45A0 /* Counter.framework in Embed Frameworks */,
+				DCF0C5F62326035C008B45A0 /* PrimeModal.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		DC29217322FB231F006090DF /* WolframAlpha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WolframAlpha.swift; sourceTree = "<group>"; };
+		DC39325F230241AF005A0B0A /* PrimeTime.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = PrimeTime.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		DC90716C22FA102900B38B42 /* PrimeTime.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PrimeTime.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC90716F22FA102900B38B42 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		DC90717122FA102900B38B42 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		DC90717322FA102900B38B42 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		DC90717522FA102A00B38B42 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		DC90717822FA102A00B38B42 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		DC90717B22FA102A00B38B42 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		DC90717D22FA102A00B38B42 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DC90718222FA102B00B38B42 /* PrimeTimeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrimeTimeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC90718622FA102B00B38B42 /* PrimeTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeTimeTests.swift; sourceTree = "<group>"; };
+		DC90718822FA102B00B38B42 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DC90719122FA151D00B38B42 /* Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
+		DCF0C59B2326032B008B45A0 /* ComposableArchitecture.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ComposableArchitecture.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DCF0C59D2326032B008B45A0 /* ComposableArchitecture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ComposableArchitecture.h; sourceTree = "<group>"; };
+		DCF0C59E2326032B008B45A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DCF0C5A32326032B008B45A0 /* ComposableArchitectureTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ComposableArchitectureTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DCF0C5AA2326032B008B45A0 /* ComposableArchitectureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposableArchitectureTests.swift; sourceTree = "<group>"; };
+		DCF0C5AC2326032B008B45A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DCF0C5BE23260348008B45A0 /* Counter.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Counter.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DCF0C5C023260348008B45A0 /* Counter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Counter.h; sourceTree = "<group>"; };
+		DCF0C5C123260348008B45A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DCF0C5C623260348008B45A0 /* CounterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CounterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DCF0C5CD23260348008B45A0 /* CounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterTests.swift; sourceTree = "<group>"; };
+		DCF0C5CF23260348008B45A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DCF0C5E02326035C008B45A0 /* PrimeModal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PrimeModal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DCF0C5E22326035C008B45A0 /* PrimeModal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrimeModal.h; sourceTree = "<group>"; };
+		DCF0C5E32326035C008B45A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DCF0C5E82326035C008B45A0 /* PrimeModalTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrimeModalTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DCF0C5EF2326035C008B45A0 /* PrimeModalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeModalTests.swift; sourceTree = "<group>"; };
+		DCF0C5F12326035C008B45A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DCF0C6022326036F008B45A0 /* FavoritePrimes.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FavoritePrimes.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DCF0C6042326036F008B45A0 /* FavoritePrimes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FavoritePrimes.h; sourceTree = "<group>"; };
+		DCF0C6052326036F008B45A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DCF0C60A2326036F008B45A0 /* FavoritePrimesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FavoritePrimesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DCF0C6112326036F008B45A0 /* FavoritePrimesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritePrimesTests.swift; sourceTree = "<group>"; };
+		DCF0C6132326036F008B45A0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DCF0C627232603B7008B45A0 /* ComposableArchitecture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposableArchitecture.swift; sourceTree = "<group>"; };
+		DCF0C62923260405008B45A0 /* FavoritePrimes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritePrimes.swift; sourceTree = "<group>"; };
+		DCF0C62B2326040D008B45A0 /* PrimeModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeModal.swift; sourceTree = "<group>"; };
+		DCF0C62D23260414008B45A0 /* Counter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Counter.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		DC90716922FA102900B38B42 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF88F02234D4A3B001BA79A /* ComposableArchitecture.framework in Frameworks */,
+				DCF0C5D323260348008B45A0 /* Counter.framework in Frameworks */,
+				DCF0C6172326036F008B45A0 /* FavoritePrimes.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DC90717F22FA102B00B38B42 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5982326032B008B45A0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5A02326032B008B45A0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C5A42326032B008B45A0 /* ComposableArchitecture.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5BB23260348008B45A0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF88F01234D4A28001BA79A /* PrimeModal.framework in Frameworks */,
+				DCF88F00234D4A28001BA79A /* ComposableArchitecture.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5C323260348008B45A0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C5C723260348008B45A0 /* Counter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5DD2326035C008B45A0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF88EFF234D4A20001BA79A /* ComposableArchitecture.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5E52326035C008B45A0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C5E92326035C008B45A0 /* PrimeModal.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5FF2326036F008B45A0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC36ED17234CD8040027F7A1 /* ComposableArchitecture.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C6072326036F008B45A0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C60B2326036F008B45A0 /* FavoritePrimes.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		DC36ED16234CD8040027F7A1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DC90716322FA102900B38B42 = {
+			isa = PBXGroup;
+			children = (
+				DC39325F230241AF005A0B0A /* PrimeTime.playground */,
+				DC90716E22FA102900B38B42 /* PrimeTime */,
+				DC90718522FA102B00B38B42 /* PrimeTimeTests */,
+				DCF0C59C2326032B008B45A0 /* ComposableArchitecture */,
+				DCF0C5A92326032B008B45A0 /* ComposableArchitectureTests */,
+				DCF0C5BF23260348008B45A0 /* Counter */,
+				DCF0C5CC23260348008B45A0 /* CounterTests */,
+				DCF0C5E12326035C008B45A0 /* PrimeModal */,
+				DCF0C5EE2326035C008B45A0 /* PrimeModalTests */,
+				DCF0C6032326036F008B45A0 /* FavoritePrimes */,
+				DCF0C6102326036F008B45A0 /* FavoritePrimesTests */,
+				DC90716D22FA102900B38B42 /* Products */,
+				DC36ED16234CD8040027F7A1 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		DC90716D22FA102900B38B42 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DC90716C22FA102900B38B42 /* PrimeTime.app */,
+				DC90718222FA102B00B38B42 /* PrimeTimeTests.xctest */,
+				DCF0C59B2326032B008B45A0 /* ComposableArchitecture.framework */,
+				DCF0C5A32326032B008B45A0 /* ComposableArchitectureTests.xctest */,
+				DCF0C5BE23260348008B45A0 /* Counter.framework */,
+				DCF0C5C623260348008B45A0 /* CounterTests.xctest */,
+				DCF0C5E02326035C008B45A0 /* PrimeModal.framework */,
+				DCF0C5E82326035C008B45A0 /* PrimeModalTests.xctest */,
+				DCF0C6022326036F008B45A0 /* FavoritePrimes.framework */,
+				DCF0C60A2326036F008B45A0 /* FavoritePrimesTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		DC90716E22FA102900B38B42 /* PrimeTime */ = {
+			isa = PBXGroup;
+			children = (
+				DC90716F22FA102900B38B42 /* AppDelegate.swift */,
+				DC90717122FA102900B38B42 /* SceneDelegate.swift */,
+				DC90717322FA102900B38B42 /* ContentView.swift */,
+				DC90719122FA151D00B38B42 /* Util.swift */,
+				DC90717522FA102A00B38B42 /* Assets.xcassets */,
+				DC90717A22FA102A00B38B42 /* LaunchScreen.storyboard */,
+				DC90717D22FA102A00B38B42 /* Info.plist */,
+				DC90717722FA102A00B38B42 /* Preview Content */,
+			);
+			path = PrimeTime;
+			sourceTree = "<group>";
+		};
+		DC90717722FA102A00B38B42 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				DC90717822FA102A00B38B42 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		DC90718522FA102B00B38B42 /* PrimeTimeTests */ = {
+			isa = PBXGroup;
+			children = (
+				DC90718622FA102B00B38B42 /* PrimeTimeTests.swift */,
+				DC90718822FA102B00B38B42 /* Info.plist */,
+			);
+			path = PrimeTimeTests;
+			sourceTree = "<group>";
+		};
+		DCF0C59C2326032B008B45A0 /* ComposableArchitecture */ = {
+			isa = PBXGroup;
+			children = (
+				DCF0C59D2326032B008B45A0 /* ComposableArchitecture.h */,
+				DCF0C627232603B7008B45A0 /* ComposableArchitecture.swift */,
+				DCF0C59E2326032B008B45A0 /* Info.plist */,
+			);
+			path = ComposableArchitecture;
+			sourceTree = "<group>";
+		};
+		DCF0C5A92326032B008B45A0 /* ComposableArchitectureTests */ = {
+			isa = PBXGroup;
+			children = (
+				DCF0C5AA2326032B008B45A0 /* ComposableArchitectureTests.swift */,
+				DCF0C5AC2326032B008B45A0 /* Info.plist */,
+			);
+			path = ComposableArchitectureTests;
+			sourceTree = "<group>";
+		};
+		DCF0C5BF23260348008B45A0 /* Counter */ = {
+			isa = PBXGroup;
+			children = (
+				DCF0C5C023260348008B45A0 /* Counter.h */,
+				DCF0C62D23260414008B45A0 /* Counter.swift */,
+				DC29217322FB231F006090DF /* WolframAlpha.swift */,
+				DCF0C5C123260348008B45A0 /* Info.plist */,
+			);
+			path = Counter;
+			sourceTree = "<group>";
+		};
+		DCF0C5CC23260348008B45A0 /* CounterTests */ = {
+			isa = PBXGroup;
+			children = (
+				DCF0C5CD23260348008B45A0 /* CounterTests.swift */,
+				DCF0C5CF23260348008B45A0 /* Info.plist */,
+			);
+			path = CounterTests;
+			sourceTree = "<group>";
+		};
+		DCF0C5E12326035C008B45A0 /* PrimeModal */ = {
+			isa = PBXGroup;
+			children = (
+				DCF0C5E22326035C008B45A0 /* PrimeModal.h */,
+				DCF0C62B2326040D008B45A0 /* PrimeModal.swift */,
+				DCF0C5E32326035C008B45A0 /* Info.plist */,
+			);
+			path = PrimeModal;
+			sourceTree = "<group>";
+		};
+		DCF0C5EE2326035C008B45A0 /* PrimeModalTests */ = {
+			isa = PBXGroup;
+			children = (
+				DCF0C5EF2326035C008B45A0 /* PrimeModalTests.swift */,
+				DCF0C5F12326035C008B45A0 /* Info.plist */,
+			);
+			path = PrimeModalTests;
+			sourceTree = "<group>";
+		};
+		DCF0C6032326036F008B45A0 /* FavoritePrimes */ = {
+			isa = PBXGroup;
+			children = (
+				DCF0C6042326036F008B45A0 /* FavoritePrimes.h */,
+				DCF0C62923260405008B45A0 /* FavoritePrimes.swift */,
+				DCF0C6052326036F008B45A0 /* Info.plist */,
+			);
+			path = FavoritePrimes;
+			sourceTree = "<group>";
+		};
+		DCF0C6102326036F008B45A0 /* FavoritePrimesTests */ = {
+			isa = PBXGroup;
+			children = (
+				DCF0C6112326036F008B45A0 /* FavoritePrimesTests.swift */,
+				DCF0C6132326036F008B45A0 /* Info.plist */,
+			);
+			path = FavoritePrimesTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		DCF0C5962326032B008B45A0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C5AD2326032B008B45A0 /* ComposableArchitecture.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5B923260348008B45A0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C5D023260348008B45A0 /* Counter.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5DB2326035C008B45A0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C5F22326035C008B45A0 /* PrimeModal.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5FD2326036F008B45A0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C6142326036F008B45A0 /* FavoritePrimes.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		DC90716B22FA102900B38B42 /* PrimeTime */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DC90718B22FA102B00B38B42 /* Build configuration list for PBXNativeTarget "PrimeTime" */;
+			buildPhases = (
+				DC90716822FA102900B38B42 /* Sources */,
+				DC90716922FA102900B38B42 /* Frameworks */,
+				DC90716A22FA102900B38B42 /* Resources */,
+				DCF0C5B12326032B008B45A0 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DCF0C5AF2326032B008B45A0 /* PBXTargetDependency */,
+				DCF0C5D223260348008B45A0 /* PBXTargetDependency */,
+				DCF0C6162326036F008B45A0 /* PBXTargetDependency */,
+			);
+			name = PrimeTime;
+			productName = PrimeTime;
+			productReference = DC90716C22FA102900B38B42 /* PrimeTime.app */;
+			productType = "com.apple.product-type.application";
+		};
+		DC90718122FA102B00B38B42 /* PrimeTimeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DC90718E22FA102B00B38B42 /* Build configuration list for PBXNativeTarget "PrimeTimeTests" */;
+			buildPhases = (
+				DC90717E22FA102B00B38B42 /* Sources */,
+				DC90717F22FA102B00B38B42 /* Frameworks */,
+				DC90718022FA102B00B38B42 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DC90718422FA102B00B38B42 /* PBXTargetDependency */,
+			);
+			name = PrimeTimeTests;
+			productName = PrimeTimeTests;
+			productReference = DC90718222FA102B00B38B42 /* PrimeTimeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DCF0C59A2326032B008B45A0 /* ComposableArchitecture */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DCF0C5B72326032B008B45A0 /* Build configuration list for PBXNativeTarget "ComposableArchitecture" */;
+			buildPhases = (
+				DCF0C5962326032B008B45A0 /* Headers */,
+				DCF0C5972326032B008B45A0 /* Sources */,
+				DCF0C5982326032B008B45A0 /* Frameworks */,
+				DCF0C5992326032B008B45A0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ComposableArchitecture;
+			productName = ComposableArchitecture;
+			productReference = DCF0C59B2326032B008B45A0 /* ComposableArchitecture.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DCF0C5A22326032B008B45A0 /* ComposableArchitectureTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DCF0C5B82326032B008B45A0 /* Build configuration list for PBXNativeTarget "ComposableArchitectureTests" */;
+			buildPhases = (
+				DCF0C59F2326032B008B45A0 /* Sources */,
+				DCF0C5A02326032B008B45A0 /* Frameworks */,
+				DCF0C5A12326032B008B45A0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DCF0C5A62326032B008B45A0 /* PBXTargetDependency */,
+				DCF0C5A82326032B008B45A0 /* PBXTargetDependency */,
+			);
+			name = ComposableArchitectureTests;
+			productName = ComposableArchitectureTests;
+			productReference = DCF0C5A32326032B008B45A0 /* ComposableArchitectureTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DCF0C5BD23260348008B45A0 /* Counter */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DCF0C5D523260348008B45A0 /* Build configuration list for PBXNativeTarget "Counter" */;
+			buildPhases = (
+				DCF0C5B923260348008B45A0 /* Headers */,
+				DCF0C5BA23260348008B45A0 /* Sources */,
+				DCF0C5BB23260348008B45A0 /* Frameworks */,
+				DCF0C5BC23260348008B45A0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CAD67E1D2332982E000C7787 /* PBXTargetDependency */,
+				DCF0C6242326038A008B45A0 /* PBXTargetDependency */,
+			);
+			name = Counter;
+			productName = Counter;
+			productReference = DCF0C5BE23260348008B45A0 /* Counter.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DCF0C5C523260348008B45A0 /* CounterTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DCF0C5D823260348008B45A0 /* Build configuration list for PBXNativeTarget "CounterTests" */;
+			buildPhases = (
+				DCF0C5C223260348008B45A0 /* Sources */,
+				DCF0C5C323260348008B45A0 /* Frameworks */,
+				DCF0C5C423260348008B45A0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DCF0C5C923260348008B45A0 /* PBXTargetDependency */,
+				DCF0C5CB23260348008B45A0 /* PBXTargetDependency */,
+			);
+			name = CounterTests;
+			productName = CounterTests;
+			productReference = DCF0C5C623260348008B45A0 /* CounterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DCF0C5DF2326035C008B45A0 /* PrimeModal */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DCF0C5F72326035C008B45A0 /* Build configuration list for PBXNativeTarget "PrimeModal" */;
+			buildPhases = (
+				DCF0C5DB2326035C008B45A0 /* Headers */,
+				DCF0C5DC2326035C008B45A0 /* Sources */,
+				DCF0C5DD2326035C008B45A0 /* Frameworks */,
+				DCF0C5DE2326035C008B45A0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DCF0C62223260387008B45A0 /* PBXTargetDependency */,
+			);
+			name = PrimeModal;
+			productName = PrimeModal;
+			productReference = DCF0C5E02326035C008B45A0 /* PrimeModal.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DCF0C5E72326035C008B45A0 /* PrimeModalTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DCF0C5FA2326035C008B45A0 /* Build configuration list for PBXNativeTarget "PrimeModalTests" */;
+			buildPhases = (
+				DCF0C5E42326035C008B45A0 /* Sources */,
+				DCF0C5E52326035C008B45A0 /* Frameworks */,
+				DCF0C5E62326035C008B45A0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DCF0C5EB2326035C008B45A0 /* PBXTargetDependency */,
+				DCF0C5ED2326035C008B45A0 /* PBXTargetDependency */,
+			);
+			name = PrimeModalTests;
+			productName = PrimeModalTests;
+			productReference = DCF0C5E82326035C008B45A0 /* PrimeModalTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DCF0C6012326036F008B45A0 /* FavoritePrimes */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DCF0C6192326036F008B45A0 /* Build configuration list for PBXNativeTarget "FavoritePrimes" */;
+			buildPhases = (
+				DCF0C5FD2326036F008B45A0 /* Headers */,
+				DCF0C5FE2326036F008B45A0 /* Sources */,
+				DCF0C5FF2326036F008B45A0 /* Frameworks */,
+				DCF0C6002326036F008B45A0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DCF0C62023260383008B45A0 /* PBXTargetDependency */,
+			);
+			name = FavoritePrimes;
+			productName = FavoritePrimes;
+			productReference = DCF0C6022326036F008B45A0 /* FavoritePrimes.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DCF0C6092326036F008B45A0 /* FavoritePrimesTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DCF0C61C2326036F008B45A0 /* Build configuration list for PBXNativeTarget "FavoritePrimesTests" */;
+			buildPhases = (
+				DCF0C6062326036F008B45A0 /* Sources */,
+				DCF0C6072326036F008B45A0 /* Frameworks */,
+				DCF0C6082326036F008B45A0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DCF0C60D2326036F008B45A0 /* PBXTargetDependency */,
+				DCF0C60F2326036F008B45A0 /* PBXTargetDependency */,
+			);
+			name = FavoritePrimesTests;
+			productName = FavoritePrimesTests;
+			productReference = DCF0C60A2326036F008B45A0 /* FavoritePrimesTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		DC90716422FA102900B38B42 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1100;
+				LastUpgradeCheck = 1100;
+				ORGANIZATIONNAME = "Point-Free";
+				TargetAttributes = {
+					DC90716B22FA102900B38B42 = {
+						CreatedOnToolsVersion = 11.0;
+					};
+					DC90718122FA102B00B38B42 = {
+						CreatedOnToolsVersion = 11.0;
+						TestTargetID = DC90716B22FA102900B38B42;
+					};
+					DCF0C59A2326032B008B45A0 = {
+						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1100;
+					};
+					DCF0C5A22326032B008B45A0 = {
+						CreatedOnToolsVersion = 11.0;
+						TestTargetID = DC90716B22FA102900B38B42;
+					};
+					DCF0C5BD23260348008B45A0 = {
+						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1100;
+					};
+					DCF0C5C523260348008B45A0 = {
+						CreatedOnToolsVersion = 11.0;
+					};
+					DCF0C5DF2326035C008B45A0 = {
+						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1100;
+					};
+					DCF0C5E72326035C008B45A0 = {
+						CreatedOnToolsVersion = 11.0;
+					};
+					DCF0C6012326036F008B45A0 = {
+						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1100;
+					};
+					DCF0C6092326036F008B45A0 = {
+						CreatedOnToolsVersion = 11.0;
+					};
+				};
+			};
+			buildConfigurationList = DC90716722FA102900B38B42 /* Build configuration list for PBXProject "PrimeTime" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = DC90716322FA102900B38B42;
+			productRefGroup = DC90716D22FA102900B38B42 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				DC90716B22FA102900B38B42 /* PrimeTime */,
+				DC90718122FA102B00B38B42 /* PrimeTimeTests */,
+				DCF0C59A2326032B008B45A0 /* ComposableArchitecture */,
+				DCF0C5A22326032B008B45A0 /* ComposableArchitectureTests */,
+				DCF0C5BD23260348008B45A0 /* Counter */,
+				DCF0C5C523260348008B45A0 /* CounterTests */,
+				DCF0C5DF2326035C008B45A0 /* PrimeModal */,
+				DCF0C5E72326035C008B45A0 /* PrimeModalTests */,
+				DCF0C6012326036F008B45A0 /* FavoritePrimes */,
+				DCF0C6092326036F008B45A0 /* FavoritePrimesTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		DC90716A22FA102900B38B42 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC90717C22FA102A00B38B42 /* LaunchScreen.storyboard in Resources */,
+				DC90717922FA102A00B38B42 /* Preview Assets.xcassets in Resources */,
+				DC90717622FA102A00B38B42 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DC90718022FA102B00B38B42 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5992326032B008B45A0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5A12326032B008B45A0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5BC23260348008B45A0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5C423260348008B45A0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5DE2326035C008B45A0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5E62326035C008B45A0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C6002326036F008B45A0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C6082326036F008B45A0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		DC90716822FA102900B38B42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC90717022FA102900B38B42 /* AppDelegate.swift in Sources */,
+				DC90717222FA102900B38B42 /* SceneDelegate.swift in Sources */,
+				DC90717422FA102900B38B42 /* ContentView.swift in Sources */,
+				DC90719222FA151D00B38B42 /* Util.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DC90717E22FA102B00B38B42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DC90718722FA102B00B38B42 /* PrimeTimeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5972326032B008B45A0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C628232603B7008B45A0 /* ComposableArchitecture.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C59F2326032B008B45A0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C5AB2326032B008B45A0 /* ComposableArchitectureTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5BA23260348008B45A0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C62E23260414008B45A0 /* Counter.swift in Sources */,
+				CAD67E2023329887000C7787 /* WolframAlpha.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5C223260348008B45A0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C5CE23260348008B45A0 /* CounterTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5DC2326035C008B45A0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C62C2326040D008B45A0 /* PrimeModal.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5E42326035C008B45A0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C5F02326035C008B45A0 /* PrimeModalTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C5FE2326036F008B45A0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C62A23260405008B45A0 /* FavoritePrimes.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCF0C6062326036F008B45A0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCF0C6122326036F008B45A0 /* FavoritePrimesTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CAD67E1D2332982E000C7787 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C5DF2326035C008B45A0 /* PrimeModal */;
+			targetProxy = CAD67E1C2332982E000C7787 /* PBXContainerItemProxy */;
+		};
+		DC90718422FA102B00B38B42 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DC90716B22FA102900B38B42 /* PrimeTime */;
+			targetProxy = DC90718322FA102B00B38B42 /* PBXContainerItemProxy */;
+		};
+		DCF0C5A62326032B008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C59A2326032B008B45A0 /* ComposableArchitecture */;
+			targetProxy = DCF0C5A52326032B008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C5A82326032B008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DC90716B22FA102900B38B42 /* PrimeTime */;
+			targetProxy = DCF0C5A72326032B008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C5AF2326032B008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C59A2326032B008B45A0 /* ComposableArchitecture */;
+			targetProxy = DCF0C5AE2326032B008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C5C923260348008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C5BD23260348008B45A0 /* Counter */;
+			targetProxy = DCF0C5C823260348008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C5CB23260348008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DC90716B22FA102900B38B42 /* PrimeTime */;
+			targetProxy = DCF0C5CA23260348008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C5D223260348008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C5BD23260348008B45A0 /* Counter */;
+			targetProxy = DCF0C5D123260348008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C5EB2326035C008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C5DF2326035C008B45A0 /* PrimeModal */;
+			targetProxy = DCF0C5EA2326035C008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C5ED2326035C008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DC90716B22FA102900B38B42 /* PrimeTime */;
+			targetProxy = DCF0C5EC2326035C008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C60D2326036F008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C6012326036F008B45A0 /* FavoritePrimes */;
+			targetProxy = DCF0C60C2326036F008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C60F2326036F008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DC90716B22FA102900B38B42 /* PrimeTime */;
+			targetProxy = DCF0C60E2326036F008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C6162326036F008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C6012326036F008B45A0 /* FavoritePrimes */;
+			targetProxy = DCF0C6152326036F008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C62023260383008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C59A2326032B008B45A0 /* ComposableArchitecture */;
+			targetProxy = DCF0C61F23260383008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C62223260387008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C59A2326032B008B45A0 /* ComposableArchitecture */;
+			targetProxy = DCF0C62123260387008B45A0 /* PBXContainerItemProxy */;
+		};
+		DCF0C6242326038A008B45A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCF0C59A2326032B008B45A0 /* ComposableArchitecture */;
+			targetProxy = DCF0C6232326038A008B45A0 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		DC90717A22FA102A00B38B42 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				DC90717B22FA102A00B38B42 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		DC90718922FA102B00B38B42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		DC90718A22FA102B00B38B42 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		DC90718C22FA102B00B38B42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "PrimeTime/Preview\\ Content";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = PrimeTime/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.PrimeTime;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DC90718D22FA102B00B38B42 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "PrimeTime/Preview\\ Content";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = PrimeTime/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.PrimeTime;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		DC90718F22FA102B00B38B42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = PrimeTimeTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.PrimeTimeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrimeTime.app/PrimeTime";
+			};
+			name = Debug;
+		};
+		DC90719022FA102B00B38B42 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = PrimeTimeTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.PrimeTimeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrimeTime.app/PrimeTime";
+			};
+			name = Release;
+		};
+		DCF0C5B32326032B008B45A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ComposableArchitecture/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.ComposableArchitecture;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		DCF0C5B42326032B008B45A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ComposableArchitecture/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.ComposableArchitecture;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		DCF0C5B52326032B008B45A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = ComposableArchitectureTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.ComposableArchitectureTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrimeTime.app/PrimeTime";
+			};
+			name = Debug;
+		};
+		DCF0C5B62326032B008B45A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = ComposableArchitectureTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.ComposableArchitectureTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PrimeTime.app/PrimeTime";
+			};
+			name = Release;
+		};
+		DCF0C5D623260348008B45A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Counter/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.Counter;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		DCF0C5D723260348008B45A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Counter/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.Counter;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		DCF0C5D923260348008B45A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = CounterTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.CounterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DCF0C5DA23260348008B45A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = CounterTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.CounterTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		DCF0C5F82326035C008B45A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = PrimeModal/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.PrimeModal;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		DCF0C5F92326035C008B45A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = PrimeModal/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.PrimeModal;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		DCF0C5FB2326035C008B45A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = PrimeModalTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.PrimeModalTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DCF0C5FC2326035C008B45A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = PrimeModalTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.PrimeModalTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		DCF0C61A2326036F008B45A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = FavoritePrimes/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.FavoritePrimes;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		DCF0C61B2326036F008B45A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = FavoritePrimes/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.FavoritePrimes;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		DCF0C61D2326036F008B45A0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = FavoritePrimesTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.FavoritePrimesTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DCF0C61E2326036F008B45A0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = FavoritePrimesTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.pointfree.FavoritePrimesTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		DC90716722FA102900B38B42 /* Build configuration list for PBXProject "PrimeTime" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DC90718922FA102B00B38B42 /* Debug */,
+				DC90718A22FA102B00B38B42 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DC90718B22FA102B00B38B42 /* Build configuration list for PBXNativeTarget "PrimeTime" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DC90718C22FA102B00B38B42 /* Debug */,
+				DC90718D22FA102B00B38B42 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DC90718E22FA102B00B38B42 /* Build configuration list for PBXNativeTarget "PrimeTimeTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DC90718F22FA102B00B38B42 /* Debug */,
+				DC90719022FA102B00B38B42 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DCF0C5B72326032B008B45A0 /* Build configuration list for PBXNativeTarget "ComposableArchitecture" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCF0C5B32326032B008B45A0 /* Debug */,
+				DCF0C5B42326032B008B45A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DCF0C5B82326032B008B45A0 /* Build configuration list for PBXNativeTarget "ComposableArchitectureTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCF0C5B52326032B008B45A0 /* Debug */,
+				DCF0C5B62326032B008B45A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DCF0C5D523260348008B45A0 /* Build configuration list for PBXNativeTarget "Counter" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCF0C5D623260348008B45A0 /* Debug */,
+				DCF0C5D723260348008B45A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DCF0C5D823260348008B45A0 /* Build configuration list for PBXNativeTarget "CounterTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCF0C5D923260348008B45A0 /* Debug */,
+				DCF0C5DA23260348008B45A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DCF0C5F72326035C008B45A0 /* Build configuration list for PBXNativeTarget "PrimeModal" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCF0C5F82326035C008B45A0 /* Debug */,
+				DCF0C5F92326035C008B45A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DCF0C5FA2326035C008B45A0 /* Build configuration list for PBXNativeTarget "PrimeModalTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCF0C5FB2326035C008B45A0 /* Debug */,
+				DCF0C5FC2326035C008B45A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DCF0C6192326036F008B45A0 /* Build configuration list for PBXNativeTarget "FavoritePrimes" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCF0C61A2326036F008B45A0 /* Debug */,
+				DCF0C61B2326036F008B45A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DCF0C61C2326036F008B45A0 /* Build configuration list for PBXNativeTarget "FavoritePrimesTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DCF0C61D2326036F008B45A0 /* Debug */,
+				DCF0C61E2326036F008B45A0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = DC90716422FA102900B38B42 /* Project object */;
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:PrimeTime.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/xcshareddata/xcschemes/Counter.xcscheme
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/xcshareddata/xcschemes/Counter.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1110"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C5BD23260348008B45A0"
+               BuildableName = "Counter.framework"
+               BlueprintName = "Counter"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C5C523260348008B45A0"
+               BuildableName = "CounterTests.xctest"
+               BlueprintName = "CounterTests"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DCF0C5BD23260348008B45A0"
+            BuildableName = "Counter.framework"
+            BlueprintName = "Counter"
+            ReferencedContainer = "container:PrimeTime.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/xcshareddata/xcschemes/FavoritePrimes.xcscheme
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/xcshareddata/xcschemes/FavoritePrimes.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1110"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C6012326036F008B45A0"
+               BuildableName = "FavoritePrimes.framework"
+               BlueprintName = "FavoritePrimes"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C6092326036F008B45A0"
+               BuildableName = "FavoritePrimesTests.xctest"
+               BlueprintName = "FavoritePrimesTests"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DCF0C6012326036F008B45A0"
+            BuildableName = "FavoritePrimes.framework"
+            BlueprintName = "FavoritePrimes"
+            ReferencedContainer = "container:PrimeTime.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/xcshareddata/xcschemes/PrimeModal.xcscheme
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/xcshareddata/xcschemes/PrimeModal.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1110"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C5DF2326035C008B45A0"
+               BuildableName = "PrimeModal.framework"
+               BlueprintName = "PrimeModal"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C5E72326035C008B45A0"
+               BuildableName = "PrimeModalTests.xctest"
+               BlueprintName = "PrimeModalTests"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DCF0C5DF2326035C008B45A0"
+            BuildableName = "PrimeModal.framework"
+            BlueprintName = "PrimeModal"
+            ReferencedContainer = "container:PrimeTime.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/xcshareddata/xcschemes/PrimeTime.xcscheme
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.xcodeproj/xcshareddata/xcschemes/PrimeTime.xcscheme
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1110"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC90716B22FA102900B38B42"
+               BuildableName = "PrimeTime.app"
+               BlueprintName = "PrimeTime"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DC90718122FA102B00B38B42"
+               BuildableName = "PrimeTimeTests.xctest"
+               BlueprintName = "PrimeTimeTests"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C5A22326032B008B45A0"
+               BuildableName = "ComposableArchitectureTests.xctest"
+               BlueprintName = "ComposableArchitectureTests"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C5C523260348008B45A0"
+               BuildableName = "CounterTests.xctest"
+               BlueprintName = "CounterTests"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C5E72326035C008B45A0"
+               BuildableName = "PrimeModalTests.xctest"
+               BlueprintName = "PrimeModalTests"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCF0C6092326036F008B45A0"
+               BuildableName = "FavoritePrimesTests.xctest"
+               BlueprintName = "FavoritePrimesTests"
+               ReferencedContainer = "container:PrimeTime.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC90716B22FA102900B38B42"
+            BuildableName = "PrimeTime.app"
+            BlueprintName = "PrimeTime"
+            ReferencedContainer = "container:PrimeTime.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DC90716B22FA102900B38B42"
+            BuildableName = "PrimeTime.app"
+            BlueprintName = "PrimeTime"
+            ReferencedContainer = "container:PrimeTime.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/AppDelegate.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/AppDelegate.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    return true
+  }
+
+  // MARK: UISceneSession Lifecycle
+
+  func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+
+  func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+  }
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Assets.xcassets/Contents.json
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Base.lproj/LaunchScreen.storyboard
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/ContentView.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/ContentView.swift
@@ -1,0 +1,138 @@
+import Combine
+import ComposableArchitecture
+import Counter
+import FavoritePrimes
+import SwiftUI
+
+struct AppState {
+  var count = 0
+  var favoritePrimes: [Int] = []
+  var loggedInUser: User? = nil
+  var activityFeed: [Activity] = []
+  var alertNthPrime: PrimeAlert? = nil
+  var isNthPrimeButtonDisabled: Bool = false
+
+  struct Activity {
+    let timestamp: Date
+    let type: ActivityType
+
+    enum ActivityType {
+      case addedFavoritePrime(Int)
+      case removedFavoritePrime(Int)
+    }
+  }
+
+  struct User {
+    let id: Int
+    let name: String
+    let bio: String
+  }
+}
+
+enum AppAction {
+  case counterView(CounterViewAction)
+  case favoritePrimes(FavoritePrimesAction)
+
+  var counterView: CounterViewAction? {
+    get {
+      guard case let .counterView(value) = self else { return nil }
+      return value
+    }
+    set {
+      guard case .counterView = self, let newValue = newValue else { return }
+      self = .counterView(newValue)
+    }
+  }
+
+  var favoritePrimes: FavoritePrimesAction? {
+    get {
+      guard case let .favoritePrimes(value) = self else { return nil }
+      return value
+    }
+    set {
+      guard case .favoritePrimes = self, let newValue = newValue else { return }
+      self = .favoritePrimes(newValue)
+    }
+  }
+}
+
+extension AppState {
+  var counterView: CounterViewState {
+    get {
+      CounterViewState(
+        alertNthPrime: self.alertNthPrime,
+        count: self.count,
+        favoritePrimes: self.favoritePrimes,
+        isNthPrimeButtonDisabled: self.isNthPrimeButtonDisabled
+      )
+    }
+    set {
+      self.alertNthPrime = newValue.alertNthPrime
+      self.count = newValue.count
+      self.favoritePrimes = newValue.favoritePrimes
+      self.isNthPrimeButtonDisabled = newValue.isNthPrimeButtonDisabled
+    }
+  }
+}
+
+let appReducer = combine(
+  pullback(counterViewReducer, value: \AppState.counterView, action: \AppAction.counterView),
+  pullback(favoritePrimesReducer, value: \.favoritePrimes, action: \.favoritePrimes)
+)
+
+func activityFeed(
+  _ reducer: @escaping Reducer<AppState, AppAction>
+) -> Reducer<AppState, AppAction> {
+
+  return { state, action in
+    switch action {
+    case .counterView(.counter),
+         .favoritePrimes(.loadedFavoritePrimes),
+         .favoritePrimes(.loadButtonTapped),
+         .favoritePrimes(.saveButtonTapped):
+      break
+    case .counterView(.primeModal(.removeFavoritePrimeTapped)):
+      state.activityFeed.append(.init(timestamp: Date(), type: .removedFavoritePrime(state.count)))
+
+    case .counterView(.primeModal(.saveFavoritePrimeTapped)):
+      state.activityFeed.append(.init(timestamp: Date(), type: .addedFavoritePrime(state.count)))
+
+    case let .favoritePrimes(.deleteFavoritePrimes(indexSet)):
+      for index in indexSet {
+        state.activityFeed.append(.init(timestamp: Date(), type: .removedFavoritePrime(state.favoritePrimes[index])))
+      }
+    }
+
+    return reducer(&state, action)
+  }
+}
+
+struct ContentView: View {
+  @ObservedObject var store: Store<AppState, AppAction>
+
+  var body: some View {
+    NavigationView {
+      List {
+        NavigationLink(
+          "Counter demo",
+          destination: CounterView(
+            store: self.store.view(
+              value: { $0.counterView },
+              action: { .counterView($0) }
+            )
+          )
+        )
+        NavigationLink(
+          "Favorite primes",
+          destination: FavoritePrimesView(
+            store: self.store.view(
+              value: { $0.favoritePrimes },
+              action: { .favoritePrimes($0) }
+            )
+          )
+        )
+      }
+      .navigationBarTitle("State management")
+    }
+  }
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/SceneDelegate.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/SceneDelegate.swift
@@ -1,0 +1,29 @@
+import ComposableArchitecture
+import SwiftUI
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    if let windowScene = scene as? UIWindowScene {
+      let window = UIWindow(windowScene: windowScene)
+      window.rootViewController = UIHostingController(
+        rootView: ContentView(
+          store: Store(
+            initialValue: AppState(),
+            reducer: with(
+              appReducer,
+              compose(
+                logging,
+                activityFeed
+              )
+            )
+          )
+        )
+      )
+      self.window = window
+      window.makeKeyAndVisible()
+    }
+  }
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Util.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/Util.swift
@@ -1,0 +1,14 @@
+func compose<A, B, C>(
+  _ f: @escaping (B) -> C,
+  _ g: @escaping (A) -> B
+  )
+  -> (A) -> C {
+
+    return { (a: A) -> C in
+      f(g(a))
+    }
+}
+
+func with<A, B>(_ a: A, _ f: (A) throws -> B) rethrows -> B {
+  return try f(a)
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTimeTests/Info.plist
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTimeTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTimeTests/PrimeTimeTests.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTimeTests/PrimeTimeTests.swift
@@ -1,0 +1,34 @@
+//
+//  PrimeTimeTests.swift
+//  PrimeTimeTests
+//
+//  Created by Stephen Celis on 8/6/19.
+//  Copyright © 2019 Point-Free. All rights reserved.
+//
+
+import XCTest
+@testable import PrimeTime
+
+class PrimeTimeTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/README.md
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/README.md
@@ -1,0 +1,99 @@
+## Composable Architecture With Merged Effects
+
+Applied Changes:
+---------------
+
+This version of the project replaces the usage of `[Effect<Action>]` with an `Effect<Action>` in the reducer typealias as the following
+
+**Before:**
+
+```swift
+public typealias Reducer<Value, Action> = (inout Value, Action) -> [Effect<Action>]
+```
+**After:**
+```swift
+public typealias Reducer<Value, Action> = (inout Value, Action) -> Effect<Action>
+```
+
+In this case our `Reducer` always returns an `Effect`, what if the applied action doesn't return an Effect? well so we need to extend the `Effect` type so we could have an `emptyEffect` that does nothing.
+
+we can achive that by the below extension on `Effect`:
+
+
+```swift
+public extension Effect {
+  static func emptyEffect(completeImmediately: Bool = true) -> Effect {
+    return Empty<Output, Never>(completeImmediately: completeImmediately).eraseToEffect()
+  }
+}
+```
+with the above in place, it could be used as a return value for every action that doesn't need any effect to be returned.
+
+**example:**
+```swift
+
+public func primeModalReducer(state: inout PrimeModalState, action: PrimeModalAction) -> Effect<PrimeModalAction> {
+  switch action {
+  case .removeFavoritePrimeTapped:
+    state.favoritePrimes.removeAll(where: { $0 == state.count })
+    return .emptyEffect()
+
+  case .saveFavoritePrimeTapped:
+    state.favoritePrimes.append(state.count)
+    return .emptyEffect()
+  }
+}
+```
+
+in order to combine multiple effects in combine reducers function we could use `Combine's MergeMany` function like the following:
+
+```swift
+public func combine<Value, Action>(
+  _ reducers: Reducer<Value, Action>...
+) -> Reducer<Value, Action> {
+  return { value, action in
+    let effects = reducers.flatMap { $0(&value, action) }
+    return Publishers.MergeMany(effects).eraseToEffect()
+  }
+}
+```
+
+in this way we unified the effect(s) to be one effect only, even if any action returns muliple effects we can use one of `Combine's Merge` overloads.
+
+### Testing
+
+when it comes to test we can test the effects as usual, in case we have an empty effect we could assert that it doesn't output any value `effects.sink { _ in XCTFail() }`
+
+**example:**
+
+```swift
+  func testPrimeModal() {
+    ...
+
+    var effects = counterViewReducer(&state, .primeModal(.saveFavoritePrimeTapped))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 2,
+        favoritePrimes: [3, 5, 2],
+        isNthPrimeButtonDisabled: false
+      )
+    )
+    effects.sink { _ in XCTFail() }
+
+    effects = counterViewReducer(&state, .primeModal(.removeFavoritePrimeTapped))
+
+    XCTAssertEqual(
+      state,
+      CounterViewState(
+        alertNthPrime: nil,
+        count: 2,
+        favoritePrimes: [3, 5],
+        isNthPrimeButtonDisabled: false
+      )
+    )
+    effects.sink { _ in XCTFail() }
+  }
+```


### PR DESCRIPTION
* Change the signature of Reducer typealias in favor of always returning an emptyEffect
* In case we need to return multiple effects we can use `Publishers.Merge`
* If we want to test an action that doesn't have an effect (returns an empty Effect) we could assert `effect.sink { _ in XCTFail() }`

Alternative consideration:
We could design the Reducer to return an optional Effect<Action> ie:
`public typealias Reducer<Value, Action> = (inout Value, Action) -> Effect<Action>?`
then return `nil` in case the action doesn't return any effect. 