### PR TITLE
Make 95 sample code build

### DIFF
--- a/0095-adaptive-state-management-pt2/PrimeTime/CounterTests/CounterTests.swift
+++ b/0095-adaptive-state-management-pt2/PrimeTime/CounterTests/CounterTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 class CounterTests: XCTestCase {
   func testSnapshots() {
-    let store = Store(initialValue: CounterViewState(), reducer: counterViewReducer, environment: { _ in .sync { 17 } })
+    let store = Store(initialValue: CounterFeatureState(), reducer: counterViewReducer, environment: { _ in .sync { 17 } })
     let view = CounterView(store: store)
 
     let vc = UIHostingController(rootView: view)
@@ -52,7 +52,7 @@ class CounterTests: XCTestCase {
 
   func testIncrDecrButtonTapped() {
     assert(
-      initialValue: CounterViewState(count: 2),
+      initialValue: CounterFeatureState(count: 2),
       reducer: counterViewReducer,
       environment: { _ in .sync { 17 } },
       steps:
@@ -64,20 +64,20 @@ class CounterTests: XCTestCase {
 
   func testNthPrimeButtonHappyFlow() {
     assert(
-      initialValue: CounterViewState(
+      initialValue: CounterFeatureState(
         alertNthPrime: nil,
         count: 7,
-        isNthPrimeButtonDisabled: false
+        isNthPrimeRequestInFlight: false
       ),
       reducer: counterViewReducer,
       environment: { _ in .sync { 17 } },
       steps:
       Step(.send, .counter(.nthPrimeButtonTapped)) {
-        $0.isNthPrimeButtonDisabled = true
+        $0.isNthPrimeRequestInFlight = true
       },
       Step(.receive, .counter(.nthPrimeResponse(n: 7, prime: 17))) {
         $0.alertNthPrime = PrimeAlert(n: $0.count, prime: 17)
-        $0.isNthPrimeButtonDisabled = false
+        $0.isNthPrimeRequestInFlight = false
       },
       Step(.send, .counter(.alertDismissButtonTapped)) {
         $0.alertNthPrime = nil
@@ -87,26 +87,26 @@ class CounterTests: XCTestCase {
 
   func testNthPrimeButtonUnhappyFlow() {
     assert(
-      initialValue: CounterViewState(
+      initialValue: CounterFeatureState(
         alertNthPrime: nil,
         count: 7,
-        isNthPrimeButtonDisabled: false
+        isNthPrimeRequestInFlight: false
       ),
       reducer: counterViewReducer,
       environment: { _ in .sync { nil } },
       steps:
       Step(.send, .counter(.nthPrimeButtonTapped)) {
-        $0.isNthPrimeButtonDisabled = true
+        $0.isNthPrimeRequestInFlight = true
       },
       Step(.receive, .counter(.nthPrimeResponse(n: 7, prime: nil))) {
-        $0.isNthPrimeButtonDisabled = false
+        $0.isNthPrimeRequestInFlight = false
       }
     )
   }
 
   func testPrimeModal() {
     assert(
-      initialValue: CounterViewState(
+      initialValue: CounterFeatureState(
         count: 1,
         favoritePrimes: [3, 5]
       ),

--- a/0095-adaptive-state-management-pt2/PrimeTime/PrimeTime.playground/Pages/Counter.xcplaygroundpage/Contents.swift
+++ b/0095-adaptive-state-management-pt2/PrimeTime/PrimeTime.playground/Pages/Counter.xcplaygroundpage/Contents.swift
@@ -10,7 +10,7 @@ PlaygroundPage.current.liveView = UIHostingController(
         alertNthPrime: nil,
         count: 0,
         favoritePrimes: [],
-        isNthPrimeButtonDisabled: false
+        isNthPrimeRequestInFlight: false
       ),
       reducer: logging(counterViewReducer),
       environment: { _ in .sync { 7236893748932 } }

--- a/0095-adaptive-state-management-pt2/PrimeTime/PrimeTime/ContentView.swift
+++ b/0095-adaptive-state-management-pt2/PrimeTime/PrimeTime/ContentView.swift
@@ -12,7 +12,7 @@ struct AppState: Equatable {
   var loggedInUser: User? = nil
   var activityFeed: [Activity] = []
   var alertNthPrime: PrimeAlert? = nil
-  var isNthPrimeButtonDisabled: Bool = false
+  var isNthPrimeRequestInFlight: Bool = false
   var isPrimeModalShown: Bool = false
 
   struct Activity: Equatable {
@@ -54,7 +54,7 @@ extension AppState {
         alertNthPrime: self.alertNthPrime,
         count: self.count,
         favoritePrimes: self.favoritePrimes,
-        isNthPrimeButtonDisabled: self.isNthPrimeButtonDisabled,
+        isNthPrimeRequestInFlight: self.isNthPrimeRequestInFlight,
         isPrimeModalShown: self.isPrimeModalShown
       )
     }
@@ -62,7 +62,7 @@ extension AppState {
       self.alertNthPrime = newValue.alertNthPrime
       self.count = newValue.count
       self.favoritePrimes = newValue.favoritePrimes
-      self.isNthPrimeButtonDisabled = newValue.isNthPrimeButtonDisabled
+      self.isNthPrimeRequestInFlight = newValue.isNthPrimeRequestInFlight
       self.isPrimeModalShown = newValue.isPrimeModalShown
     }
   }
@@ -111,7 +111,7 @@ func activityFeed(
          .favoritePrimes(.loadedFavoritePrimes),
          .favoritePrimes(.loadButtonTapped),
          .favoritePrimes(.saveButtonTapped),
-         .favoritePrimes(.primeButtonTapped(_)),
+         .favoritePrimes(.primeButtonTapped),
          .favoritePrimes(.nthPrimeResponse),
          .favoritePrimes(.alertDismissButtonTapped):
       break

--- a/0095-adaptive-state-management-pt2/PrimeTime/PrimeTimeTests/PrimeTimeTests.swift
+++ b/0095-adaptive-state-management-pt2/PrimeTime/PrimeTimeTests/PrimeTimeTests.swift
@@ -22,10 +22,10 @@ class PrimeTimeTests: XCTestCase {
       ),
       steps:
       Step(.send, .counterView(.counter(.nthPrimeButtonTapped))) {
-        $0.isNthPrimeButtonDisabled = true
+        $0.isNthPrimeRequestInFlight = true
       },
       Step(.receive, .counterView(.counter(.nthPrimeResponse(n: 4, prime: 17)))) {
-        $0.isNthPrimeButtonDisabled = false
+        $0.isNthPrimeRequestInFlight = false
         $0.alertNthPrime = PrimeAlert(n: 4, prime: 17)
       },
       Step(.send, .favoritePrimes(.loadButtonTapped)),


### PR DESCRIPTION
The project was failing to build due to a mismatch between `AppState.isNthPrimeButtonDisabled` & `CounterFeatureState.isNthPrimeRequestInFlight`. This PR fixes the build error as well as logically renaming the `AppState` counterpart to `isNthPrimeRequestInFlight` as well.