### PR TITLE
Added this test to the .none case: if context.navigationController?.v…

### DIFF
--- a/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/ItemRowCellView.swift
+++ b/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/ItemRowCellView.swift
@@ -29,9 +29,13 @@ class ItemRowCellView: UICollectionViewListCell {
         case .none:
           guard let vc = presentedViewController
           else { return }
-          vc.dismiss(animated: true)
-          context.navigationController?.popToViewController(vc, animated: true)
-          context.navigationController?.popViewController(animated: true)
+          
+          if context.navigationController?.viewControllers.contains(vc) == true {
+            context.navigationController?.popToViewController(vc, animated: true)
+            context.navigationController?.popViewController(animated: true)
+          } else {
+            vc.dismiss(animated: true)
+          }
           presentedViewController = nil
           
         case .deleteAlert:


### PR DESCRIPTION
The main branch of episode 170 UIKit Navigation: Part 2 has a crash when you confirm a delete of an item in the inventory list.  I think that is because this code: 
```
if context.navigationController?.viewControllers.contains(vc) == true {
    context.navigationController?.popToViewController(vc, animated: true)
    context.navigationController?.popViewController(animated: true)
  } else {
    vc.dismiss(animated: true)
  }
```

That is discussed at 33:30 in the transcript of session 170, but not in the video (I don't think) is not included in the main branch.
All I did was add the code from the transcript to the file.