### PR TITLE
fix for #124

### DIFF
--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -35,7 +35,7 @@ enum EffectsBasicsAction: Equatable {
   case incrementButtonTapped
   case nthPrimeButtonTapped
   case nthPrimeProgress(Double)
-  case nthPrimeResponse(Int)
+  case nthPrimeResponse(for: Int, is: Int)
   case numberFactButtonTapped
   case numberFactResponse(TaskResult<String>)
   case startTimerButtonTapped
@@ -147,7 +147,7 @@ let effectsBasicsReducer = Reducer<
         }
       }
 
-      await send(.nthPrimeResponse(prime - 1), animation: .default)
+      await send(.nthPrimeResponse(for: count, is: prime - 1), animation: .default)
 
       // viewStore.send(action, animation: .default)
     }
@@ -156,8 +156,8 @@ let effectsBasicsReducer = Reducer<
     state.nthPrimeProgress = progress
     return .none
 
-  case let .nthPrimeResponse(prime):
-    state.numberFact = "The \(state.count)th prime is \(prime)."
+  case let .nthPrimeResponse(count, prime):
+    state.numberFact = "The \(count)th prime is \(prime)."
     state.nthPrimeProgress = nil
     return .none
 

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudiesTests/02-Effects-BasicsTests.swift
@@ -161,7 +161,7 @@ class EffectsBasicsTests: XCTestCase {
     await store.receive(.nthPrimeProgress(0.84)) {
       $0.nthPrimeProgress = 0.84
     }
-    await store.receive(.nthPrimeResponse(1_223)) {
+    await store.receive(.nthPrimeResponse(for: 200, is: 1_223)) {
       $0.numberFact = "The 200th prime is 1223."
       $0.nthPrimeProgress = nil
     }


### PR DESCRIPTION
Need to pass the captured count for which we are calculating a prime to .nthPrimeResponse so it can construct an accurate number fact display string.