### PR TITLE
Apply deprecation of NavigationView

### DIFF
--- a/0065-swiftui-and-state-management-pt1/StateManagement.playground/Contents.swift
+++ b/0065-swiftui-and-state-management-pt1/StateManagement.playground/Contents.swift
@@ -5,7 +5,7 @@ struct ContentView: View {
   @ObservedObject var state: AppState
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(destination: CounterView(state: self.state)) {
           Text("Counter demo")

--- a/0066-swiftui-and-state-management-pt2/StateManagement.playground/Contents.swift
+++ b/0066-swiftui-and-state-management-pt2/StateManagement.playground/Contents.swift
@@ -65,7 +65,7 @@ struct ContentView: View {
   @ObservedObject var state: AppState
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(destination: CounterView(state: self.state)) {
           Text("Counter demo")

--- a/0067-swiftui-and-state-management-pt3/StateManagement.playground/Contents.swift
+++ b/0067-swiftui-and-state-management-pt3/StateManagement.playground/Contents.swift
@@ -65,7 +65,7 @@ struct ContentView: View {
   @ObservedObject var state: AppState
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(destination: CounterView(state: self.state)) {
           Text("Counter demo")

--- a/0068-composable-state-management-reducers/ComposableArchitecture.playground/Contents.swift
+++ b/0068-composable-state-management-reducers/ComposableArchitecture.playground/Contents.swift
@@ -196,7 +196,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0069-composable-state-management-state-pullbacks/ComposableArchitecture.playground/Contents.swift
+++ b/0069-composable-state-management-state-pullbacks/ComposableArchitecture.playground/Contents.swift
@@ -262,7 +262,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0070-composable-state-management-action-pullbacks/ComposableArchitecture.playground/Contents.swift
+++ b/0070-composable-state-management-action-pullbacks/ComposableArchitecture.playground/Contents.swift
@@ -353,7 +353,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0071-composable-state-management-hor/ComposableArchitecture.playground/Contents.swift
+++ b/0071-composable-state-management-hor/ComposableArchitecture.playground/Contents.swift
@@ -386,7 +386,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0072-modular-state-management-reducers/PrimeTime/PrimeTime/ContentView.swift
+++ b/0072-modular-state-management-reducers/PrimeTime/PrimeTime/ContentView.swift
@@ -234,7 +234,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0073-modular-state-management-view-state/PrimeTime/PrimeTime/ContentView.swift
+++ b/0073-modular-state-management-view-state/PrimeTime/PrimeTime/ContentView.swift
@@ -239,7 +239,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0074-modular-state-management-view-actions/PrimeTime/PrimeTime/ContentView.swift
+++ b/0074-modular-state-management-view-actions/PrimeTime/PrimeTime/ContentView.swift
@@ -115,7 +115,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0075-modular-state-management-wtp/PrimeTime/PrimeTime/ContentView.swift
+++ b/0075-modular-state-management-wtp/PrimeTime/PrimeTime/ContentView.swift
@@ -104,7 +104,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0076-effectful-state-management-synchronous-effects/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0076-effectful-state-management-synchronous-effects/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@ import PlaygroundSupport
 import SwiftUI
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0076-effectful-state-management-synchronous-effects/PrimeTime/PrimeTime/ContentView.swift
+++ b/0076-effectful-state-management-synchronous-effects/PrimeTime/PrimeTime/ContentView.swift
@@ -105,7 +105,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0077-effectful-state-management-unidirectional-effects/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0077-effectful-state-management-unidirectional-effects/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@ import PlaygroundSupport
 import SwiftUI
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0077-effectful-state-management-unidirectional-effects/PrimeTime/PrimeTime/ContentView.swift
+++ b/0077-effectful-state-management-unidirectional-effects/PrimeTime/PrimeTime/ContentView.swift
@@ -105,7 +105,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0078-effectful-state-management-async-effects/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0078-effectful-state-management-async-effects/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@ import PlaygroundSupport
 import SwiftUI
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0078-effectful-state-management-async-effects/PrimeTime/PrimeTime/ContentView.swift
+++ b/0078-effectful-state-management-async-effects/PrimeTime/PrimeTime/ContentView.swift
@@ -105,7 +105,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0079-effectful-state-management-wtp/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0079-effectful-state-management-wtp/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@ import PlaygroundSupport
 import SwiftUI
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0079-effectful-state-management-wtp/PrimeTime/PrimeTime/ContentView.swift
+++ b/0079-effectful-state-management-wtp/PrimeTime/PrimeTime/ContentView.swift
@@ -111,7 +111,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0081-combine-and-effects-pt2/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0081-combine-and-effects-pt2/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@ import PlaygroundSupport
 import SwiftUI
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0081-combine-and-effects-pt2/PrimeTime/PrimeTime/ContentView.swift
+++ b/0081-combine-and-effects-pt2/PrimeTime/PrimeTime/ContentView.swift
@@ -111,7 +111,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0081-combine-and-effects-pt2/ReactiveSwiftPrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0081-combine-and-effects-pt2/ReactiveSwiftPrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@ import PlaygroundSupport
 import SwiftUI
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0081-combine-and-effects-pt2/ReactiveSwiftPrimeTime/PrimeTime/ContentView.swift
+++ b/0081-combine-and-effects-pt2/ReactiveSwiftPrimeTime/PrimeTime/ContentView.swift
@@ -111,7 +111,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0081-combine-and-effects-pt2/RxPrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0081-combine-and-effects-pt2/RxPrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@ import PlaygroundSupport
 import SwiftUI
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0081-combine-and-effects-pt2/RxPrimeTime/PrimeTime/ContentView.swift
+++ b/0081-combine-and-effects-pt2/RxPrimeTime/PrimeTime/ContentView.swift
@@ -111,7 +111,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0082-testable-state-management-reducers/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0082-testable-state-management-reducers/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@ Current.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0082-testable-state-management-reducers/PrimeTime/PrimeTime/ContentView.swift
+++ b/0082-testable-state-management-reducers/PrimeTime/PrimeTime/ContentView.swift
@@ -111,7 +111,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@ Current.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/ContentView.swift
+++ b/0083-testable-state-management-effects/PrimeTime-MergedEffect/PrimeTime/ContentView.swift
@@ -111,7 +111,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0083-testable-state-management-effects/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0083-testable-state-management-effects/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@ Current.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0083-testable-state-management-effects/PrimeTime/PrimeTime/ContentView.swift
+++ b/0083-testable-state-management-effects/PrimeTime/PrimeTime/ContentView.swift
@@ -111,7 +111,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0084-testable-state-management-ergonomics/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0084-testable-state-management-ergonomics/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@ Current.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0084-testable-state-management-ergonomics/PrimeTime/PrimeTime/ContentView.swift
+++ b/0084-testable-state-management-ergonomics/PrimeTime/PrimeTime/ContentView.swift
@@ -111,7 +111,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0085-testable-state-management-the-point/VanillaPrimeTime/VanillaPrimeTime/ContentView.swift
+++ b/0085-testable-state-management-the-point/VanillaPrimeTime/VanillaPrimeTime/ContentView.swift
@@ -36,7 +36,7 @@ struct ContentView: View {
   @ObservedObject var state: AppState
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(destination: CounterView(state: self.state)) {
           Text("Counter demo")

--- a/0086-swiftui-snapshot-testing/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0086-swiftui-snapshot-testing/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@ Current.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0086-swiftui-snapshot-testing/PrimeTime/PrimeTime/ContentView.swift
+++ b/0086-swiftui-snapshot-testing/PrimeTime/PrimeTime/ContentView.swift
@@ -114,7 +114,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0090-composing-architecture-with-case-paths/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0090-composing-architecture-with-case-paths/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@ Current.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0090-composing-architecture-with-case-paths/PrimeTime/PrimeTime/ContentView.swift
+++ b/0090-composing-architecture-with-case-paths/PrimeTime/PrimeTime/ContentView.swift
@@ -124,7 +124,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0091-modular-dependency-injection-pt1/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0091-modular-dependency-injection-pt1/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@ Current.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0091-modular-dependency-injection-pt1/PrimeTime/PrimeTime/ContentView.swift
+++ b/0091-modular-dependency-injection-pt1/PrimeTime/PrimeTime/ContentView.swift
@@ -101,7 +101,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0092-modular-dependency-injection-pt2/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0092-modular-dependency-injection-pt2/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@ environment.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<[Int], FavoritePrimesAction>(
         initialValue: [2, 3, 5, 7, 11],

--- a/0092-modular-dependency-injection-pt2/PrimeTime/PrimeTime/ContentView.swift
+++ b/0092-modular-dependency-injection-pt2/PrimeTime/PrimeTime/ContentView.swift
@@ -113,7 +113,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         NavigationLink(
           "Counter demo",

--- a/0093-modular-dependency-injection-pt3/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0093-modular-dependency-injection-pt3/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ environment.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store<FavoritePrimesState, FavoritePrimesAction>(
         initialValue: (

--- a/0093-modular-dependency-injection-pt3/PrimeTime/PrimeTime/ContentView.swift
+++ b/0093-modular-dependency-injection-pt3/PrimeTime/PrimeTime/ContentView.swift
@@ -139,7 +139,7 @@ struct ContentView: View {
   @ObservedObject var store: Store<AppState, AppAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         if !isInExperiment {
           NavigationLink(

--- a/0094-adaptive-state-management-pt1/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0094-adaptive-state-management-pt1/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ environment.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store(
         initialValue: (

--- a/0094-adaptive-state-management-pt1/PrimeTime/PrimeTime/ContentView.swift
+++ b/0094-adaptive-state-management-pt1/PrimeTime/PrimeTime/ContentView.swift
@@ -145,7 +145,7 @@ struct ContentView: View {
 
   var body: some View {
     print("ContentView.body")
-    return NavigationView {
+    return NavigationStack {
       List {
         if !isInExperiment {
           NavigationLink(

--- a/0095-adaptive-state-management-pt2/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0095-adaptive-state-management-pt2/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ environment.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store(
         initialValue: (

--- a/0095-adaptive-state-management-pt2/PrimeTime/PrimeTime/ContentView.swift
+++ b/0095-adaptive-state-management-pt2/PrimeTime/PrimeTime/ContentView.swift
@@ -146,7 +146,7 @@ struct ContentView: View {
 
   var body: some View {
     print("ContentView.body")
-    return NavigationView {
+    return NavigationStack {
       List {
         if !isInExperiment {
           NavigationLink(

--- a/0096-adaptive-state-management-pt3/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0096-adaptive-state-management-pt3/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ environment.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store(
         initialValue: (

--- a/0096-adaptive-state-management-pt3/PrimeTime/PrimeTime/ContentView.swift
+++ b/0096-adaptive-state-management-pt3/PrimeTime/PrimeTime/ContentView.swift
@@ -138,7 +138,7 @@ let isInExperiment = false //Bool.random()
 struct ContentView: View {
   let store: Store<AppState, AppAction>
 //  @ObservedObject var viewStore: ViewStore<???>
-  
+
   init(store: Store<AppState, AppAction>) {
     print("ContentView.init")
     self.store = store

--- a/0096-adaptive-state-management-pt3/PrimeTime/PrimeTime/ContentView.swift
+++ b/0096-adaptive-state-management-pt3/PrimeTime/PrimeTime/ContentView.swift
@@ -146,7 +146,7 @@ struct ContentView: View {
 
   var body: some View {
     print("ContentView.body")
-    return NavigationView {
+    return NavigationStack {
       List {
         if !isInExperiment {
           NavigationLink(

--- a/0097-adaptive-state-management-pt4/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0097-adaptive-state-management-pt4/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ environment.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store(
         initialValue: (

--- a/0097-adaptive-state-management-pt4/PrimeTime/PrimeTime/ContentView.swift
+++ b/0097-adaptive-state-management-pt4/PrimeTime/PrimeTime/ContentView.swift
@@ -146,7 +146,7 @@ struct ContentView: View {
 
   var body: some View {
     print("ContentView.body")
-    return NavigationView {
+    return NavigationStack {
       List {
         if !isInExperiment {
           NavigationLink(

--- a/0098-ergonomic-state-management-pt1/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0098-ergonomic-state-management-pt1/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ environment.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store(
         initialValue: (

--- a/0098-ergonomic-state-management-pt1/PrimeTime/PrimeTime/ContentView.swift
+++ b/0098-ergonomic-state-management-pt1/PrimeTime/PrimeTime/ContentView.swift
@@ -170,7 +170,7 @@ struct ContentView: View {
 
   var body: some View {
     print("ContentView.body")
-    return NavigationView {
+    return NavigationStack {
       List {
         if !isInExperiment {
           NavigationLink(

--- a/0099-ergonomic-state-management-pt2/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
+++ b/0099-ergonomic-state-management-pt2/PrimeTime/PrimeTime.playground/Pages/Favorite Primes.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ environment.fileClient.load = { _ in
 }
 
 PlaygroundPage.current.liveView = UIHostingController(
-  rootView: NavigationView {
+  rootView: NavigationStack {
     FavoritePrimesView(
       store: Store(
         initialValue: (

--- a/0099-ergonomic-state-management-pt2/PrimeTime/PrimeTime/ContentView.swift
+++ b/0099-ergonomic-state-management-pt2/PrimeTime/PrimeTime/ContentView.swift
@@ -170,7 +170,7 @@ struct ContentView: View {
 
   var body: some View {
     print("ContentView.body")
-    return NavigationView {
+    return NavigationStack {
       List {
         if !isInExperiment {
           NavigationLink(

--- a/0100-swift-composable-architecture-tour-pt1/Todos/Todos/ContentView.swift
+++ b/0100-swift-composable-architecture-tour-pt1/Todos/Todos/ContentView.swift
@@ -36,7 +36,7 @@ struct ContentView: View {
 //  @ObservableObject var viewStore
   
   var body: some View {
-    NavigationView {
+    NavigationStack {
       WithViewStore(self.store) { viewStore in
         List {
 //          zip(viewStore.todos.indices, viewStore.todos)

--- a/0101-swift-composable-architecture-tour-pt2/Todos/Todos/ContentView.swift
+++ b/0101-swift-composable-architecture-tour-pt2/Todos/Todos/ContentView.swift
@@ -75,7 +75,7 @@ struct ContentView: View {
 //  @ObservableObject var viewStore
   
   var body: some View {
-    NavigationView {
+    NavigationStack {
       WithViewStore(self.store) { viewStore in
         List {
           ForEachStore(

--- a/0102-swift-composable-architecture-tour-pt3/Todos/Todos/ContentView.swift
+++ b/0102-swift-composable-architecture-tour-pt3/Todos/Todos/ContentView.swift
@@ -98,7 +98,7 @@ struct ContentView: View {
 //  @ObservableObject var viewStore
   
   var body: some View {
-    NavigationView {
+    NavigationStack {
       WithViewStore(self.store) { viewStore in
         List {
           ForEachStore(

--- a/0103-swift-composable-architecture-tour-pt4/Todos/Todos/ContentView.swift
+++ b/0103-swift-composable-architecture-tour-pt4/Todos/Todos/ContentView.swift
@@ -110,7 +110,7 @@ struct ContentView: View {
 //  @ObservableObject var viewStore
   
   var body: some View {
-    NavigationView {
+    NavigationStack {
       WithViewStore(self.store) { viewStore in
         List {
           ForEachStore(

--- a/0104-combine-schedulers-pt1/CombineSchedulers/CombineSchedulers/ContentView.swift
+++ b/0104-combine-schedulers-pt1/CombineSchedulers/CombineSchedulers/ContentView.swift
@@ -83,7 +83,7 @@ struct ContentView: View {
   @ObservedObject var viewModel: RegisterViewModel
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       if self.viewModel.isRegistered {
         Text("Welcome!")
       } else {

--- a/0105-combine-schedulers-pt2/CombineSchedulers/CombineSchedulers/ContentView.swift
+++ b/0105-combine-schedulers-pt2/CombineSchedulers/CombineSchedulers/ContentView.swift
@@ -80,7 +80,7 @@ struct ContentView: View {
   @ObservedObject var viewModel: RegisterViewModel
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       if self.viewModel.isRegistered {
         Text("Welcome!")
       } else {

--- a/0106-combine-schedulers-pt3/CombineSchedulers/CombineSchedulers/ContentView.swift
+++ b/0106-combine-schedulers-pt3/CombineSchedulers/CombineSchedulers/ContentView.swift
@@ -90,7 +90,7 @@ struct ContentView: View {
   @ObservedObject var viewModel: RegisterViewModel
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       if self.viewModel.isRegistered {
         Text("Welcome!")
       } else {

--- a/0107-composable-bindings-pt1/Inventory/Inventory/ContentView.swift
+++ b/0107-composable-bindings-pt1/Inventory/Inventory/ContentView.swift
@@ -139,7 +139,7 @@ struct ContentView_Previews: PreviewProvider {
       }
     }
 
-    return NavigationView {
+    return NavigationStack {
       Wrapper()
     }
   }

--- a/0108-composable-bindings-pt2/Inventory/Inventory/ContentView.swift
+++ b/0108-composable-bindings-pt2/Inventory/Inventory/ContentView.swift
@@ -244,7 +244,7 @@ struct InventoryView: View {
   @ObservedObject var viewModel: InventoryViewModel
   
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         ForEach(self.viewModel.inventory, id: \.self) { item in
           HStack {
@@ -288,7 +288,7 @@ struct InventoryView: View {
 //        .sheet(item: self.$viewModel.draft) { _ in
 //          self.$viewModel.draft.unwrap().map { item in
         .sheet(unwrap: self.$viewModel.draft) { item in
-          NavigationView {
+          NavigationStack {
             ItemView(item: item)
               .navigationBarItems(
                 leading: Button("Cancel") { self.viewModel.cancelButtonTapped() },
@@ -343,7 +343,7 @@ struct ContentView_Previews: PreviewProvider {
       }
     }
 
-    return NavigationView {
+    return NavigationStack {
       Wrapper()
     }
   }

--- a/0109-composable-bindings-pt3/Inventory/Inventory/ContentView.swift
+++ b/0109-composable-bindings-pt3/Inventory/Inventory/ContentView.swift
@@ -244,7 +244,7 @@ struct InventoryView: View {
   @ObservedObject var viewModel: InventoryViewModel
   
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         ForEach(self.viewModel.inventory, id: \.self) { item in
           HStack {
@@ -288,7 +288,7 @@ struct InventoryView: View {
 //        .sheet(item: self.$viewModel.draft) { _ in
 //          self.$viewModel.draft.unwrap().map { item in
         .sheet(unwrap: self.$viewModel.draft) { item in
-          NavigationView {
+          NavigationStack {
             ItemView(item: item)
               .navigationBarItems(
                 leading: Button("Cancel") { self.viewModel.cancelButtonTapped() },
@@ -343,7 +343,7 @@ struct ContentView_Previews: PreviewProvider {
       }
     }
 
-    return NavigationView {
+    return NavigationStack {
       Wrapper()
     }
   }

--- a/0110-designing-dependencies-pt1/DesigningDependencies/DesigningDependencies/ContentView.swift
+++ b/0110-designing-dependencies-pt1/DesigningDependencies/DesigningDependencies/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
   @ObservedObject var viewModel: AppViewModel
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       ZStack(alignment: .bottom) {
         ZStack(alignment: .bottomTrailing) {
           List {

--- a/0111-designing-dependencies-pt2/DesigningDependencies/WeatherFeature/ContentView.swift
+++ b/0111-designing-dependencies-pt2/DesigningDependencies/WeatherFeature/ContentView.swift
@@ -32,7 +32,7 @@ public struct ContentView: View {
   }
 
   public var body: some View {
-    NavigationView {
+    NavigationStack {
       ZStack(alignment: .bottom) {
         ZStack(alignment: .bottomTrailing) {
           List {

--- a/0112-designing-dependencies-pt3/DesigningDependencies/WeatherFeature/ContentView.swift
+++ b/0112-designing-dependencies-pt3/DesigningDependencies/WeatherFeature/ContentView.swift
@@ -67,7 +67,7 @@ public struct ContentView: View {
   }
 
   public var body: some View {
-    NavigationView {
+    NavigationStack {
       ZStack(alignment: .bottom) {
         ZStack(alignment: .bottomTrailing) {
           List {

--- a/0113-designing-dependencies-pt4/DesigningDependencies/WeatherFeature/ContentView.swift
+++ b/0113-designing-dependencies-pt4/DesigningDependencies/WeatherFeature/ContentView.swift
@@ -138,7 +138,7 @@ public struct ContentView: View {
   }
 
   public var body: some View {
-    NavigationView {
+    NavigationStack {
       ZStack(alignment: .bottom) {
         ZStack(alignment: .bottomTrailing) {
           List {

--- a/0114-designing-dependencies-pt5/DesigningDependencies/WeatherFeature/ContentView.swift
+++ b/0114-designing-dependencies-pt5/DesigningDependencies/WeatherFeature/ContentView.swift
@@ -138,7 +138,7 @@ public struct ContentView: View {
   }
 
   public var body: some View {
-    NavigationView {
+    NavigationStack {
       ZStack(alignment: .bottom) {
         ZStack(alignment: .bottomTrailing) {
           List {

--- a/0115-redacted-swiftui-pt1/Articles/Shared/Composable.swift
+++ b/0115-redacted-swiftui-pt1/Articles/Shared/Composable.swift
@@ -61,7 +61,7 @@ struct ComposableArticlesView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         List {
           if viewStore.isLoading {
             ActivityIndicator()
@@ -74,7 +74,7 @@ struct ComposableArticlesView: View {
         .sheet(
           item: viewStore.binding(get: \.readingArticle, send: .dismissArticle)
         ) { article in
-          NavigationView {
+          NavigationStack {
             ArticleDetailView(article: article)
               .navigationTitle(article.title)
           }

--- a/0115-redacted-swiftui-pt1/Articles/Shared/Vanilla.swift
+++ b/0115-redacted-swiftui-pt1/Articles/Shared/Vanilla.swift
@@ -27,7 +27,7 @@ struct VanillaArticlesView: View {
   @ObservedObject private var viewModel = AppViewModel()
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         if self.viewModel.isLoading {
           ActivityIndicator()
@@ -53,7 +53,7 @@ struct VanillaArticlesView: View {
         .disabled(self.viewModel.isLoading)
       }
       .sheet(item: self.$viewModel.readingArticle) { article in
-        NavigationView {
+        NavigationStack {
           ArticleDetailView(article: article)
             .navigationTitle(article.title)
         }

--- a/0116-redacted-swiftui-pt2/Articles/Shared/Composable.swift
+++ b/0116-redacted-swiftui-pt2/Articles/Shared/Composable.swift
@@ -61,7 +61,7 @@ struct ComposableArticlesView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         List {
           if viewStore.isLoading {
             ActivityIndicator()
@@ -74,7 +74,7 @@ struct ComposableArticlesView: View {
         .sheet(
           item: viewStore.binding(get: \.readingArticle, send: .dismissArticle)
         ) { article in
-          NavigationView {
+          NavigationStack {
             ArticleDetailView(article: article)
               .navigationTitle(article.title)
           }

--- a/0116-redacted-swiftui-pt2/Articles/Shared/Vanilla.swift
+++ b/0116-redacted-swiftui-pt2/Articles/Shared/Vanilla.swift
@@ -27,7 +27,7 @@ struct VanillaArticlesView: View {
   @ObservedObject private var viewModel = AppViewModel()
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         if self.viewModel.isLoading {
           ActivityIndicator()
@@ -53,7 +53,7 @@ struct VanillaArticlesView: View {
         .disabled(self.viewModel.isLoading)
       }
       .sheet(item: self.$viewModel.readingArticle) { article in
-        NavigationView {
+        NavigationStack {
           ArticleDetailView(article: article)
             .navigationTitle(article.title)
         }

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndActionSheets.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndActionSheets.swift
@@ -119,7 +119,7 @@ struct AlertAndSheetView: View {
 
 struct AlertAndSheet_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndSheetView(
         store: .init(
           initialState: .init(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -129,7 +129,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(circleCenter: CGPoint(x: 50, y: 50)),
@@ -141,7 +141,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(circleCenter: CGPoint(x: 50, y: 50)),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -125,7 +125,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -66,7 +66,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -63,7 +63,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -81,7 +81,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -91,7 +91,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -129,7 +129,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -121,7 +121,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -109,8 +109,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -121,7 +121,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -344,7 +344,7 @@ private class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: .init(receivedMessages: ["Echo"]),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-SystemEnvironment.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-SystemEnvironment.swift
@@ -136,7 +136,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: .init(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -123,7 +123,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -109,7 +109,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -95,7 +95,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -91,7 +91,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -97,7 +97,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -89,7 +89,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -144,7 +144,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -152,7 +152,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: .init(
             initialState: .init(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -147,7 +147,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -192,7 +192,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: .init(cityMaps: .mocks),
@@ -205,7 +205,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: [CityMapState].mocks.first!,

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -192,7 +192,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-StrictReducers.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-StrictReducers.swift
@@ -83,7 +83,7 @@ struct DieRollView: View {
 
 struct DieRollView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       DieRollView(
         store: Store(
           initialState: DieRollState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -37,7 +37,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: .init(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/LocationManager/Mobile/LocationManagerView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/LocationManager/Mobile/LocationManagerView.swift
@@ -64,7 +64,7 @@ struct LocationManagerView: View {
 
 struct ContentView: View {
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section(
           header: Text(readMe)

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -92,7 +92,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/RootView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/RootView.swift
@@ -38,7 +38,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section(
           header: Text(readMe).padding([.bottom], 16)

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
@@ -14,14 +14,14 @@ public struct AppView: View {
 
   @ViewBuilder public var body: some View {
     IfLetStore(self.store.scope(state: { $0.login }, action: AppAction.login)) { store in
-      NavigationView {
+      NavigationStack {
         LoginView(store: store)
       }
       .navigationViewStyle(StackNavigationViewStyle())
     }
 
     IfLetStore(self.store.scope(state: { $0.newGame }, action: AppAction.newGame)) { store in
-      NavigationView {
+      NavigationStack {
         NewGameView(store: store)
       }
       .navigationViewStyle(StackNavigationViewStyle())

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/GameSwiftView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/GameSwiftView.swift
@@ -97,7 +97,7 @@ extension GameState {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
@@ -123,7 +123,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/NewGameSwiftView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/NewGameSwiftView.swift
@@ -102,7 +102,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/TwoFactorSwiftView.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/TwoFactorSwiftView.swift
@@ -89,7 +89,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -110,7 +110,7 @@ struct AppView: View {
 
   var body: some View {
     WithViewStore(self.store.scope(state: { $0.view })) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           WithViewStore(self.store.scope(state: { $0.filter }, action: AppAction.filterPicked)) {
             filterViewStore in

--- a/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0117-redacted-swiftui-pt3/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -188,7 +188,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndActionSheets.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndActionSheets.swift
@@ -119,7 +119,7 @@ struct AlertAndSheetView: View {
 
 struct AlertAndSheet_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndSheetView(
         store: .init(
           initialState: .init(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -129,7 +129,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(circleCenter: CGPoint(x: 50, y: 50)),
@@ -141,7 +141,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(circleCenter: CGPoint(x: 50, y: 50)),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -125,7 +125,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -66,7 +66,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -63,7 +63,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -81,7 +81,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -91,7 +91,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -129,7 +129,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -121,7 +121,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -109,8 +109,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -121,7 +121,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -344,7 +344,7 @@ private class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: .init(receivedMessages: ["Echo"]),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-SystemEnvironment.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Effects-SystemEnvironment.swift
@@ -136,7 +136,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: .init(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -123,7 +123,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -109,7 +109,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -95,7 +95,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -91,7 +91,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -97,7 +97,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -89,7 +89,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -144,7 +144,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -152,7 +152,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: .init(
             initialState: .init(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -147,7 +147,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -192,7 +192,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: .init(cityMaps: .mocks),
@@ -205,7 +205,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: [CityMapState].mocks.first!,

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -192,7 +192,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-StrictReducers.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-StrictReducers.swift
@@ -83,7 +83,7 @@ struct DieRollView: View {
 
 struct DieRollView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       DieRollView(
         store: Store(
           initialState: DieRollState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -37,7 +37,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: .init(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/LocationManager/Mobile/LocationManagerView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/LocationManager/Mobile/LocationManagerView.swift
@@ -64,7 +64,7 @@ struct LocationManagerView: View {
 
 struct ContentView: View {
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section(
           header: Text(readMe)

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -92,7 +92,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/RootView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/RootView.swift
@@ -38,7 +38,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section(
           header: Text(readMe).padding([.bottom], 16)

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/AppSwiftView.swift
@@ -14,14 +14,14 @@ public struct AppView: View {
 
   @ViewBuilder public var body: some View {
     IfLetStore(self.store.scope(state: { $0.login }, action: AppAction.login)) { store in
-      NavigationView {
+      NavigationStack {
         LoginView(store: store)
       }
       .navigationViewStyle(StackNavigationViewStyle())
     }
 
     IfLetStore(self.store.scope(state: { $0.newGame }, action: AppAction.newGame)) { store in
-      NavigationView {
+      NavigationStack {
         NewGameView(store: store)
       }
       .navigationViewStyle(StackNavigationViewStyle())

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/GameSwiftView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/GameSwiftView.swift
@@ -97,7 +97,7 @@ extension GameState {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/LoginSwiftView.swift
@@ -123,7 +123,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/NewGameSwiftView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/NewGameSwiftView.swift
@@ -102,7 +102,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/TwoFactorSwiftView.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/TicTacToe/Sources/Views-SwiftUI/TwoFactorSwiftView.swift
@@ -89,7 +89,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -110,7 +110,7 @@ struct AppView: View {
 
   var body: some View {
     WithViewStore(self.store.scope(state: { $0.view })) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           WithViewStore(self.store.scope(state: { $0.filter }, action: AppAction.filterPicked)) {
             filterViewStore in

--- a/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0118-redacted-swiftui-pt4/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -188,7 +188,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0131-concise-forms-pt1/ConciseForms/ConciseForms/ConciseFormsApp.swift
+++ b/0131-concise-forms-pt1/ConciseForms/ConciseForms/ConciseFormsApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct ConciseFormsApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
         VanillaSwiftUIFormView(viewModel: SettingsViewModel())
       }
     }

--- a/0131-concise-forms-pt1/ConciseForms/ConciseForms/VanillaSwiftUIFormView.swift
+++ b/0131-concise-forms-pt1/ConciseForms/ConciseForms/VanillaSwiftUIFormView.swift
@@ -114,7 +114,7 @@ enum Digest: String, CaseIterable {
 
 struct VanillaSwiftUIFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       VanillaSwiftUIFormView(
         viewModel: SettingsViewModel()
       )

--- a/0132-concise-forms-pt2/ConciseForms/ConciseForms/ConciseFormsApp.swift
+++ b/0132-concise-forms-pt2/ConciseForms/ConciseForms/ConciseFormsApp.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct ConciseFormsApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
 //        VanillaSwiftUIFormView(viewModel: SettingsViewModel())
 
         TCAFormView(

--- a/0132-concise-forms-pt2/ConciseForms/ConciseForms/TCAFormView.swift
+++ b/0132-concise-forms-pt2/ConciseForms/ConciseForms/TCAFormView.swift
@@ -209,7 +209,7 @@ struct TCAFormView: View {
 
 struct TCAFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TCAFormView(
         store: Store(
           initialState: SettingsState(),

--- a/0132-concise-forms-pt2/ConciseForms/ConciseForms/VanillaSwiftUIFormView.swift
+++ b/0132-concise-forms-pt2/ConciseForms/ConciseForms/VanillaSwiftUIFormView.swift
@@ -114,7 +114,7 @@ enum Digest: String, CaseIterable {
 
 struct VanillaSwiftUIFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       VanillaSwiftUIFormView(
         viewModel: SettingsViewModel()
       )

--- a/0133-concise-forms-pt3/ConciseForms/ConciseForms/ConciseFormsApp.swift
+++ b/0133-concise-forms-pt3/ConciseForms/ConciseForms/ConciseFormsApp.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct ConciseFormsApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
 //        VanillaSwiftUIFormView(viewModel: SettingsViewModel())
 
 //        TCAFormView(

--- a/0133-concise-forms-pt3/ConciseForms/ConciseForms/ConciseTCAFormView.swift
+++ b/0133-concise-forms-pt3/ConciseForms/ConciseForms/ConciseTCAFormView.swift
@@ -301,7 +301,7 @@ extension ViewStore {
 
 struct ConciseTCAFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ConciseTCAFormView(
         store: Store(
           initialState: SettingsState(),

--- a/0133-concise-forms-pt3/ConciseForms/ConciseForms/TCAFormView.swift
+++ b/0133-concise-forms-pt3/ConciseForms/ConciseForms/TCAFormView.swift
@@ -211,7 +211,7 @@ struct TCAFormView: View {
 
 struct TCAFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TCAFormView(
         store: Store(
           initialState: SettingsState(),

--- a/0133-concise-forms-pt3/ConciseForms/ConciseForms/VanillaSwiftUIFormView.swift
+++ b/0133-concise-forms-pt3/ConciseForms/ConciseForms/VanillaSwiftUIFormView.swift
@@ -114,7 +114,7 @@ enum Digest: String, CaseIterable {
 
 struct VanillaSwiftUIFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       VanillaSwiftUIFormView(
         viewModel: SettingsViewModel()
       )

--- a/0138-better-test-dependencies-pt1/Todos/Todos/Todos.swift
+++ b/0138-better-test-dependencies-pt1/Todos/Todos/Todos.swift
@@ -104,7 +104,7 @@ struct AppView: View {
 
   var body: some View {
     WithViewStore(self.store.scope(state: { $0.view })) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           WithViewStore(self.store.scope(state: { $0.filter }, action: AppAction.filterPicked)) {
             filterViewStore in

--- a/0139-better-test-dependencies-pt2/Todos/Todos/Todos.swift
+++ b/0139-better-test-dependencies-pt2/Todos/Todos/Todos.swift
@@ -111,7 +111,7 @@ struct AppView: View {
 
   var body: some View {
     WithViewStore(self.store.scope(state: { $0.view })) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           WithViewStore(self.store.scope(state: { $0.filter }, action: AppAction.filterPicked)) {
             filterViewStore in

--- a/0140-better-test-dependencies-pt3/DesigningDependencies/WeatherFeature/ContentView.swift
+++ b/0140-better-test-dependencies-pt3/DesigningDependencies/WeatherFeature/ContentView.swift
@@ -143,7 +143,7 @@ public struct ContentView: View {
   }
 
   public var body: some View {
-    NavigationView {
+    NavigationStack {
       ZStack(alignment: .bottom) {
         ZStack(alignment: .bottomTrailing) {
           List {

--- a/0141-better-test-dependencies-pt4/DesigningDependencies/WeatherFeature/ContentView.swift
+++ b/0141-better-test-dependencies-pt4/DesigningDependencies/WeatherFeature/ContentView.swift
@@ -143,7 +143,7 @@ public struct ContentView: View {
   }
 
   public var body: some View {
-    NavigationView {
+    NavigationStack {
       ZStack(alignment: .bottom) {
         ZStack(alignment: .bottomTrailing) {
           List {

--- a/0148-derived-behavior-pt3/DerivedBehavior/DerivedBehavior/CounterView.swift
+++ b/0148-derived-behavior-pt3/DerivedBehavior/DerivedBehavior/CounterView.swift
@@ -196,7 +196,7 @@ struct AppView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AppView(
         store: .init(
           initialState: .init(counters: []),

--- a/0148-derived-behavior-pt3/DerivedBehavior/DerivedBehavior/DerivedBehaviorApp.swift
+++ b/0148-derived-behavior-pt3/DerivedBehavior/DerivedBehavior/DerivedBehaviorApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct DerivedBehaviorApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
       AppView(
         store: .init(initialState: AppState.init(counters: []), reducer: appReducer, environment: AppEnvironment(fact: .live, mainQueue: .main, uuid: UUID.init))
       )

--- a/0149-derived-behavior-pt4/DerivedBehavior/DerivedBehavior/CounterView.swift
+++ b/0149-derived-behavior-pt4/DerivedBehavior/DerivedBehavior/CounterView.swift
@@ -346,7 +346,7 @@ struct FactPrompt: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AppView(
         store: .init(
           initialState: .init(counters: []),

--- a/0149-derived-behavior-pt4/DerivedBehavior/DerivedBehavior/DerivedBehaviorApp.swift
+++ b/0149-derived-behavior-pt4/DerivedBehavior/DerivedBehavior/DerivedBehaviorApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct DerivedBehaviorApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
       AppView(
         store: .init(initialState: AppState.init(counters: []), reducer: appReducer, environment: AppEnvironment(fact: .live, mainQueue: .main, uuid: UUID.init))
       )

--- a/0150-derived-behavior-pt5/DerivedBehavior/DerivedBehavior/CounterView.swift
+++ b/0150-derived-behavior-pt5/DerivedBehavior/DerivedBehavior/CounterView.swift
@@ -326,7 +326,7 @@ struct FactPrompt: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AppView(
         store: .init(
           initialState: .init(counters: []),

--- a/0150-derived-behavior-pt5/DerivedBehavior/DerivedBehavior/DerivedBehaviorApp.swift
+++ b/0150-derived-behavior-pt5/DerivedBehavior/DerivedBehavior/DerivedBehaviorApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct DerivedBehaviorApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
 //      AppView(
 //        store: .init(initialState: AppState.init(counters: []), reducer: appReducer, environment: AppEnvironment(fact: .live, mainQueue: .main, uuid: UUID.init))
 //      )

--- a/0150-derived-behavior-pt5/DerivedBehavior/DerivedBehavior/VanillaView.swift
+++ b/0150-derived-behavior-pt5/DerivedBehavior/DerivedBehavior/VanillaView.swift
@@ -322,7 +322,7 @@ struct VanillaAppView: View {
 
 struct Vanilla_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       VanillaAppView(
         viewModel: .init(
           fact: .live,

--- a/0156-searchable-pt1/Search/Search/ContentView.swift
+++ b/0156-searchable-pt1/Search/Search/ContentView.swift
@@ -214,7 +214,7 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ContentView(
         store: .init(
           initialState: .init(),

--- a/0156-searchable-pt1/Search/Search/SearchApp.swift
+++ b/0156-searchable-pt1/Search/Search/SearchApp.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct SearchApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
         ContentView(
           store: .init(
             initialState: .init(),

--- a/0157-searchable-pt2/Search/Search/ContentView.swift
+++ b/0157-searchable-pt2/Search/Search/ContentView.swift
@@ -243,7 +243,7 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ContentView(
         store: .init(
           initialState: .init(),

--- a/0157-searchable-pt2/Search/Search/SearchApp.swift
+++ b/0157-searchable-pt2/Search/Search/SearchApp.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct SearchApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
         ContentView(
           store: .init(
             initialState: .init(),

--- a/0158-safer-conciser-forms-pt1/ConciseForms/ConciseForms/1-VanillaSwiftUIFormView.swift
+++ b/0158-safer-conciser-forms-pt1/ConciseForms/ConciseForms/1-VanillaSwiftUIFormView.swift
@@ -112,7 +112,7 @@ struct VanillaSwiftUIFormView: View {
 
 struct VanillaSwiftUIFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       VanillaSwiftUIFormView(
         viewModel: SettingsViewModel()
       )

--- a/0158-safer-conciser-forms-pt1/ConciseForms/ConciseForms/2-InconciseTCAFormView.swift
+++ b/0158-safer-conciser-forms-pt1/ConciseForms/ConciseForms/2-InconciseTCAFormView.swift
@@ -189,7 +189,7 @@ struct InconciseSettingsView: View {
 
 struct InconciseSettingsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       InconciseSettingsView(
         store: Store(
           initialState: InconciseSettingsState(),

--- a/0158-safer-conciser-forms-pt1/ConciseForms/ConciseForms/3-ConciseTCAFormView.swift
+++ b/0158-safer-conciser-forms-pt1/ConciseForms/ConciseForms/3-ConciseTCAFormView.swift
@@ -188,7 +188,7 @@ struct TCAFormView: View {
 
 struct TCAFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TCAFormView(
         store: Store(
           initialState: .init(),

--- a/0158-safer-conciser-forms-pt1/ConciseForms/ConciseForms/ConciseFormsApp.swift
+++ b/0158-safer-conciser-forms-pt1/ConciseForms/ConciseForms/ConciseFormsApp.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct ConciseFormsApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
         TCAFormView(
           store: Store(
             initialState: .init(),

--- a/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/1-VanillaSwiftUIFormView.swift
+++ b/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/1-VanillaSwiftUIFormView.swift
@@ -125,7 +125,7 @@ struct VanillaSwiftUIFormView: View {
 
 struct VanillaSwiftUIFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       VanillaSwiftUIFormView(
         viewModel: SettingsViewModel()
       )

--- a/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/2-InconciseTCAFormView.swift
+++ b/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/2-InconciseTCAFormView.swift
@@ -189,7 +189,7 @@ struct InconciseSettingsView: View {
 
 struct InconciseSettingsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       InconciseSettingsView(
         store: Store(
           initialState: InconciseSettingsState(),

--- a/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/3-ConciseTCAFormView.swift
+++ b/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/3-ConciseTCAFormView.swift
@@ -147,7 +147,7 @@ struct TCAFormView: View {
 
 struct TCAFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TCAFormView(
         store: Store(
           initialState: .init(),

--- a/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/ConciseFormsApp.swift
+++ b/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/ConciseFormsApp.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct ConciseFormsApp: App {
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
         TCAFormView(
           store: Store(
             initialState: .init(),

--- a/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/FocusState.swift
+++ b/0159-safer-conciser-forms-pt2/ConciseForms/ConciseForms/FocusState.swift
@@ -79,7 +79,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: .init(),

--- a/0162-navigation-pt3/SwiftUINavigation/SwiftUINavigation/ContentView.swift
+++ b/0162-navigation-pt3/SwiftUINavigation/SwiftUINavigation/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0162-navigation-pt3/SwiftUINavigation/SwiftUINavigation/Inventory.swift
+++ b/0162-navigation-pt3/SwiftUINavigation/SwiftUINavigation/Inventory.swift
@@ -147,7 +147,7 @@ struct InventoryView: View {
     .navigationTitle("Inventory")
 //    .sheet(isPresented: self.$addItemIsPresented) {
     .sheet(item: self.$viewModel.itemToAdd) { itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(
           item: itemToAdd,
           onSave: { self.viewModel.add(item: $0) },
@@ -162,7 +162,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0162-navigation-pt3/SwiftUINavigation/SwiftUINavigation/ItemView.swift
+++ b/0162-navigation-pt3/SwiftUINavigation/SwiftUINavigation/ItemView.swift
@@ -67,7 +67,7 @@ struct ItemView: View {
 
 struct ItemView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ItemView(onSave: { _ in }, onCancel: { })
     }
   }

--- a/0163-navigation-pt4/SwiftUINavigation/SwiftUINavigation/ContentView.swift
+++ b/0163-navigation-pt4/SwiftUINavigation/SwiftUINavigation/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0163-navigation-pt4/SwiftUINavigation/SwiftUINavigation/Inventory.swift
+++ b/0163-navigation-pt4/SwiftUINavigation/SwiftUINavigation/Inventory.swift
@@ -115,7 +115,7 @@ struct InventoryView: View {
     .navigationTitle("Inventory")
 //    .sheet(isPresented: self.$addItemIsPresented) {
     .sheet(unwrap: self.$viewModel.itemToAdd) { $itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(item: $itemToAdd)
           .navigationTitle("Add")
           .toolbar {
@@ -150,7 +150,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0163-navigation-pt4/SwiftUINavigation/SwiftUINavigation/ItemView.swift
+++ b/0163-navigation-pt4/SwiftUINavigation/SwiftUINavigation/ItemView.swift
@@ -49,7 +49,7 @@ struct ItemView_Previews: PreviewProvider {
   }
   
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WrapperView()
     }
   }

--- a/0164-navigation-pt5/SwiftUINavigation/SwiftUINavigation/ContentView.swift
+++ b/0164-navigation-pt5/SwiftUINavigation/SwiftUINavigation/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0164-navigation-pt5/SwiftUINavigation/SwiftUINavigation/Inventory.swift
+++ b/0164-navigation-pt5/SwiftUINavigation/SwiftUINavigation/Inventory.swift
@@ -120,7 +120,7 @@ struct InventoryView: View {
     .navigationTitle("Inventory")
 //    .sheet(isPresented: self.$addItemIsPresented) {
     .sheet(unwrap: self.$viewModel.itemToAdd) { $itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(item: $itemToAdd)
           .navigationTitle("Add")
           .toolbar {
@@ -155,7 +155,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0164-navigation-pt5/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
+++ b/0164-navigation-pt5/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
@@ -116,7 +116,7 @@ struct ItemRowView: View {
       }
     )
     .sheet(unwrap: self.$viewModel.route.case(/ItemRowViewModel.Route.edit)) { $item in
-      NavigationView {
+      NavigationStack {
         ItemView(item: $item)
           .navigationBarTitle("Edit")
           .toolbar {
@@ -134,7 +134,7 @@ struct ItemRowView: View {
       }
     }
     .popover(unwrap: self.$viewModel.route.case(/ItemRowViewModel.Route.duplicate)) { $item in
-      NavigationView {
+      NavigationStack {
         ItemView(item: $item)
           .navigationBarTitle("Duplicate")
           .toolbar {

--- a/0164-navigation-pt5/SwiftUINavigation/SwiftUINavigation/ItemView.swift
+++ b/0164-navigation-pt5/SwiftUINavigation/SwiftUINavigation/ItemView.swift
@@ -49,7 +49,7 @@ struct ItemView_Previews: PreviewProvider {
   }
   
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WrapperView()
     }
   }

--- a/0165-navigation-pt6/SwiftUINavigation/SwiftUINavigation/ContentView.swift
+++ b/0165-navigation-pt6/SwiftUINavigation/SwiftUINavigation/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0165-navigation-pt6/SwiftUINavigation/SwiftUINavigation/Inventory.swift
+++ b/0165-navigation-pt6/SwiftUINavigation/SwiftUINavigation/Inventory.swift
@@ -119,7 +119,7 @@ struct InventoryView: View {
     }
     .navigationTitle("Inventory")
     .sheet(unwrap: self.$viewModel.itemToAdd) { $itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(item: $itemToAdd)
           .navigationTitle("Add")
           .toolbar {
@@ -149,7 +149,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0165-navigation-pt6/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
+++ b/0165-navigation-pt6/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
@@ -155,7 +155,7 @@ struct ItemRowView: View {
         }
       )
       //    .sheet(unwrap: self.$viewModel.route.case(/ItemRowViewModel.Route.edit)) { $item in
-      //      NavigationView {
+      //      NavigationStack {
       //        ItemView(item: $item)
       //          .navigationBarTitle("Edit")
       //          .toolbar {
@@ -173,7 +173,7 @@ struct ItemRowView: View {
       //      }
       //    }
       .popover(unwrap: self.$viewModel.route.case(/ItemRowViewModel.Route.duplicate)) { $item in
-        NavigationView {
+        NavigationStack {
           ItemView(item: $item)
             .navigationBarTitle("Duplicate")
             .toolbar {

--- a/0165-navigation-pt6/SwiftUINavigation/SwiftUINavigation/ItemView.swift
+++ b/0165-navigation-pt6/SwiftUINavigation/SwiftUINavigation/ItemView.swift
@@ -48,7 +48,7 @@ struct ItemView_Previews: PreviewProvider {
   }
   
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WrapperView()
     }
   }

--- a/0166-navigation-pt7/SwiftUINavigation/SwiftUINavigation/ContentView.swift
+++ b/0166-navigation-pt7/SwiftUINavigation/SwiftUINavigation/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0166-navigation-pt7/SwiftUINavigation/SwiftUINavigation/Inventory.swift
+++ b/0166-navigation-pt7/SwiftUINavigation/SwiftUINavigation/Inventory.swift
@@ -144,7 +144,7 @@ struct InventoryView: View {
     }
     .navigationTitle("Inventory")
     .sheet(unwrap: self.$viewModel.route.case(/InventoryViewModel.Route.add)) { $itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(item: $itemToAdd)
           .navigationTitle("Add")
           .toolbar {
@@ -174,7 +174,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0166-navigation-pt7/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
+++ b/0166-navigation-pt7/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
@@ -171,7 +171,7 @@ struct ItemRowView: View {
         }
       )
       //    .sheet(unwrap: self.$viewModel.route.case(/ItemRowViewModel.Route.edit)) { $item in
-      //      NavigationView {
+      //      NavigationStack {
       //        ItemView(item: $item)
       //          .navigationBarTitle("Edit")
       //          .toolbar {
@@ -192,7 +192,7 @@ struct ItemRowView: View {
         unwrap: self.$viewModel.route,
         case: /ItemRowViewModel.Route.duplicate
       ) { $item in
-        NavigationView {
+        NavigationStack {
           ItemView(item: $item)
             .navigationBarTitle("Duplicate")
             .toolbar {

--- a/0166-navigation-pt7/SwiftUINavigation/SwiftUINavigation/ItemView.swift
+++ b/0166-navigation-pt7/SwiftUINavigation/SwiftUINavigation/ItemView.swift
@@ -48,7 +48,7 @@ struct ItemView_Previews: PreviewProvider {
   }
   
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WrapperView()
     }
   }

--- a/0167-navigation-pt8/SwiftUINavigation/SwiftUINavigation/ContentView.swift
+++ b/0167-navigation-pt8/SwiftUINavigation/SwiftUINavigation/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0167-navigation-pt8/SwiftUINavigation/SwiftUINavigation/Inventory.swift
+++ b/0167-navigation-pt8/SwiftUINavigation/SwiftUINavigation/Inventory.swift
@@ -159,7 +159,7 @@ struct InventoryView: View {
     }
     .navigationTitle("Inventory")
     .sheet(item: self.$viewModel.route.case(/InventoryViewModel.Route.add)) { itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(viewModel: itemToAdd)
           .navigationTitle("Add")
           .toolbar {
@@ -189,7 +189,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0167-navigation-pt8/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
+++ b/0167-navigation-pt8/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
@@ -184,7 +184,7 @@ struct ItemRowView: View {
         }
       )
       //    .sheet(unwrap: self.$viewModel.route.case(/ItemRowViewModel.Route.edit)) { $item in
-      //      NavigationView {
+      //      NavigationStack {
       //        ItemView(item: $item)
       //          .navigationBarTitle("Edit")
       //          .toolbar {
@@ -204,7 +204,7 @@ struct ItemRowView: View {
       .popover(
         item: self.$viewModel.route.case(/ItemRowViewModel.Route.duplicate)
       ) { itemViewModel in
-        NavigationView {
+        NavigationStack {
           ItemView(viewModel: itemViewModel)
             .navigationBarTitle("Duplicate")
             .toolbar {

--- a/0167-navigation-pt8/SwiftUINavigation/SwiftUINavigation/ItemView.swift
+++ b/0167-navigation-pt8/SwiftUINavigation/SwiftUINavigation/ItemView.swift
@@ -160,7 +160,7 @@ struct ItemView: View {
 
 struct ItemView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ItemView(
         viewModel: .init(
           item: Item(name: "", color: nil, status: .inStock(quantity: 1))

--- a/0168-navigation-pt9/SwiftUINavigation/SwiftUINavigation/ContentView.swift
+++ b/0168-navigation-pt9/SwiftUINavigation/SwiftUINavigation/ContentView.swift
@@ -238,7 +238,7 @@ struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0168-navigation-pt9/SwiftUINavigation/SwiftUINavigation/Inventory.swift
+++ b/0168-navigation-pt9/SwiftUINavigation/SwiftUINavigation/Inventory.swift
@@ -161,7 +161,7 @@ struct InventoryView: View {
     }
     .navigationTitle("Inventory")
     .sheet(item: self.$viewModel.route.case(/InventoryViewModel.Route.add)) { itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(viewModel: itemToAdd)
           .navigationTitle("Add")
           .toolbar {
@@ -191,7 +191,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0168-navigation-pt9/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
+++ b/0168-navigation-pt9/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
@@ -184,7 +184,7 @@ struct ItemRowView: View {
         }
       )
       //    .sheet(unwrap: self.$viewModel.route.case(/ItemRowViewModel.Route.edit)) { $item in
-      //      NavigationView {
+      //      NavigationStack {
       //        ItemView(item: $item)
       //          .navigationBarTitle("Edit")
       //          .toolbar {
@@ -204,7 +204,7 @@ struct ItemRowView: View {
       .popover(
         item: self.$viewModel.route.case(/ItemRowViewModel.Route.duplicate)
       ) { itemViewModel in
-        NavigationView {
+        NavigationStack {
           ItemView(viewModel: itemViewModel)
             .navigationBarTitle("Duplicate")
             .toolbar {

--- a/0168-navigation-pt9/SwiftUINavigation/SwiftUINavigation/ItemView.swift
+++ b/0168-navigation-pt9/SwiftUINavigation/SwiftUINavigation/ItemView.swift
@@ -160,7 +160,7 @@ struct ItemView: View {
 
 struct ItemView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ItemView(
         viewModel: .init(
           item: Item(name: "", color: nil, status: .inStock(quantity: 1))

--- a/0169-uikit-navigation-pt1/SwiftUINavigation/SwiftUINavigation/ContentView.swift
+++ b/0169-uikit-navigation-pt1/SwiftUINavigation/SwiftUINavigation/ContentView.swift
@@ -225,7 +225,7 @@ struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0169-uikit-navigation-pt1/SwiftUINavigation/SwiftUINavigation/Inventory.swift
+++ b/0169-uikit-navigation-pt1/SwiftUINavigation/SwiftUINavigation/Inventory.swift
@@ -161,7 +161,7 @@ struct InventoryView: View {
     }
     .navigationTitle("Inventory")
     .sheet(item: self.$viewModel.route.case(/InventoryViewModel.Route.add)) { itemToAdd in
-      NavigationView {
+      NavigationStack {
 //        ItemView(viewModel: itemToAdd)
         ToSwiftUI {
           ItemViewController(viewModel: itemToAdd)
@@ -184,7 +184,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0169-uikit-navigation-pt1/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
+++ b/0169-uikit-navigation-pt1/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
@@ -164,7 +164,7 @@ struct ItemRowView: View {
       .popover(
         item: self.$viewModel.route.case(/ItemRowViewModel.Route.duplicate)
       ) { itemViewModel in
-        NavigationView {
+        NavigationStack {
 //          ItemView(viewModel: itemViewModel)
           ToSwiftUI {
             ItemViewController(viewModel: itemViewModel)

--- a/0169-uikit-navigation-pt1/SwiftUINavigation/SwiftUINavigation/ItemView.swift
+++ b/0169-uikit-navigation-pt1/SwiftUINavigation/SwiftUINavigation/ItemView.swift
@@ -149,7 +149,7 @@ struct ItemView: View {
 
 struct ItemView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ItemView(
         viewModel: .init(
           item: Item(name: "", color: nil, status: .inStock(quantity: 1))

--- a/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/ContentView.swift
+++ b/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/ContentView.swift
@@ -225,7 +225,7 @@ struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/Inventory.swift
+++ b/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/Inventory.swift
@@ -161,7 +161,7 @@ struct InventoryView: View {
     }
     .navigationTitle("Inventory")
     .sheet(item: self.$viewModel.route.case(/InventoryViewModel.Route.add)) { itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(viewModel: itemToAdd)
           .navigationTitle("Add")
           .toolbar {
@@ -181,7 +181,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
+++ b/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/ItemRow.swift
@@ -169,7 +169,7 @@ struct ItemRowView: View {
       .popover(
         item: self.$viewModel.route.case(/ItemRowViewModel.Route.duplicate)
       ) { itemViewModel in
-        NavigationView {
+        NavigationStack {
           ItemView(viewModel: itemViewModel)
             .navigationBarTitle("Duplicate")
             .toolbar {

--- a/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/ItemView.swift
+++ b/0170-uikit-navigation-pt2/SwiftUINavigation/SwiftUINavigation/ItemView.swift
@@ -149,7 +149,7 @@ struct ItemView: View {
 
 struct ItemView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ItemView(
         viewModel: .init(
           item: Item(name: "", color: nil, status: .inStock(quantity: 1))

--- a/0171-modularization-pt1/Inventory/Sources/AppFeature/ContentView.swift
+++ b/0171-modularization-pt1/Inventory/Sources/AppFeature/ContentView.swift
@@ -156,7 +156,7 @@ public struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0171-modularization-pt1/Inventory/Sources/InventoryFeature/Inventory.swift
+++ b/0171-modularization-pt1/Inventory/Sources/InventoryFeature/Inventory.swift
@@ -125,7 +125,7 @@ public struct InventoryView: View {
     }
     .navigationTitle("Inventory")
     .sheet(item: self.$viewModel.route.case(/InventoryViewModel.Route.add)) { itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(viewModel: itemToAdd)
           .navigationTitle("Add")
           .toolbar {
@@ -145,7 +145,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0171-modularization-pt1/Inventory/Sources/ItemFeature/ItemView.swift
+++ b/0171-modularization-pt1/Inventory/Sources/ItemFeature/ItemView.swift
@@ -157,7 +157,7 @@ public struct ItemView: View {
 
 struct ItemView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ItemView(
         viewModel: .init(
           item: Item(name: "", color: nil, status: .inStock(quantity: 1))

--- a/0171-modularization-pt1/Inventory/Sources/ItemRowFeature/ItemRow.swift
+++ b/0171-modularization-pt1/Inventory/Sources/ItemRowFeature/ItemRow.swift
@@ -176,7 +176,7 @@ public struct ItemRowView: View {
       .popover(
         item: self.$viewModel.route.case(/ItemRowViewModel.Route.duplicate)
       ) { itemViewModel in
-        NavigationView {
+        NavigationStack {
           ItemView(viewModel: itemViewModel)
             .navigationBarTitle("Duplicate")
             .toolbar {
@@ -200,7 +200,7 @@ public struct ItemRowView: View {
 
 struct ItemRowPreviews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       List {
         ItemRowView(
           viewModel: .init(

--- a/0172-modularization-pt2/Inventory/Sources/AppFeature/ContentView.swift
+++ b/0172-modularization-pt2/Inventory/Sources/AppFeature/ContentView.swift
@@ -75,7 +75,7 @@ public struct ContentView: View {
         .tabItem { Text("One") }
         .tag(Tab.one)
 
-      NavigationView {
+      NavigationStack {
         InventoryView(viewModel: self.viewModel.inventoryViewModel)
       }
         .tabItem { Text("Inventory") }

--- a/0172-modularization-pt2/Inventory/Sources/InventoryFeature/Inventory.swift
+++ b/0172-modularization-pt2/Inventory/Sources/InventoryFeature/Inventory.swift
@@ -125,7 +125,7 @@ public struct InventoryView: View {
     }
     .navigationTitle("Inventory")
     .sheet(item: self.$viewModel.route.case(/InventoryViewModel.Route.add)) { itemToAdd in
-      NavigationView {
+      NavigationStack {
         ItemView(viewModel: itemToAdd)
           .navigationTitle("Add")
           .toolbar {
@@ -145,7 +145,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
     
-    NavigationView {
+    NavigationStack {
       InventoryView(
         viewModel: .init(
           inventory: [

--- a/0172-modularization-pt2/Inventory/Sources/ItemFeature/ItemView.swift
+++ b/0172-modularization-pt2/Inventory/Sources/ItemFeature/ItemView.swift
@@ -157,7 +157,7 @@ public struct ItemView: View {
 
 struct ItemView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ItemView(
         viewModel: .init(
           item: Item(name: "", color: nil, status: .inStock(quantity: 1))

--- a/0172-modularization-pt2/Inventory/Sources/ItemRowFeature/ItemRow.swift
+++ b/0172-modularization-pt2/Inventory/Sources/ItemRowFeature/ItemRow.swift
@@ -176,7 +176,7 @@ public struct ItemRowView: View {
       .popover(
         item: self.$viewModel.route.case(/ItemRowViewModel.Route.duplicate)
       ) { itemViewModel in
-        NavigationView {
+        NavigationStack {
           ItemView(viewModel: itemViewModel)
             .navigationBarTitle("Duplicate")
             .toolbar {
@@ -200,7 +200,7 @@ public struct ItemRowView: View {
 
 struct ItemRowPreviews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       List {
         ItemRowView(
           viewModel: .init(

--- a/0172-modularization-pt2/Inventory/SwiftUINavigation/ItemRowPreviewApp/ItemRowPreviewAppApp.swift
+++ b/0172-modularization-pt2/Inventory/SwiftUINavigation/ItemRowPreviewApp/ItemRowPreviewAppApp.swift
@@ -8,7 +8,7 @@ struct ItemRowPreviewAppApp: App {
   
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
         List {
           ItemRowView(
             viewModel: self.viewModel

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -157,7 +157,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -169,7 +169,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -128,7 +128,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -109,7 +109,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -68,7 +68,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -67,7 +67,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -86,7 +86,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -87,7 +87,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -97,7 +97,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -149,7 +149,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -129,7 +129,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -109,8 +109,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -142,7 +142,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -119,7 +119,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -348,7 +348,7 @@ private class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -133,7 +133,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -108,7 +108,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -100,7 +100,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -110,7 +110,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -98,7 +98,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -141,7 +141,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -154,7 +154,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -153,7 +153,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -191,7 +191,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -204,7 +204,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -190,7 +190,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -36,7 +36,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: RootState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -114,7 +114,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
@@ -40,7 +40,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Text(readMe)
 

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,13 +14,13 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
         .navigationViewStyle(.stack)
       }
       CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
         .navigationViewStyle(.stack)

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -94,7 +94,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -120,7 +120,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -99,7 +99,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -121,7 +121,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       VStack(alignment: .leading) {
         Picker(
           "Filter",

--- a/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0195-tca-concurrency-pt1/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -187,7 +187,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -157,7 +157,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -169,7 +169,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -128,7 +128,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -109,7 +109,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -68,7 +68,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -67,7 +67,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -86,7 +86,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -87,7 +87,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -97,7 +97,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -146,7 +146,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -129,7 +129,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -109,8 +109,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -142,7 +142,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -119,7 +119,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -348,7 +348,7 @@ private class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -133,7 +133,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -108,7 +108,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -100,7 +100,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -110,7 +110,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -98,7 +98,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -141,7 +141,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -154,7 +154,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -153,7 +153,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -191,7 +191,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -204,7 +204,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -190,7 +190,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -36,7 +36,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: RootState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -114,7 +114,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
@@ -40,7 +40,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Text(readMe)
 

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,13 +14,13 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
         .navigationViewStyle(.stack)
       }
       CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
         .navigationViewStyle(.stack)

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -94,7 +94,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -120,7 +120,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -99,7 +99,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -121,7 +121,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       VStack(alignment: .leading) {
         Picker(
           "Filter",

--- a/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0196-tca-concurrency-pt2/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -187,7 +187,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -157,7 +157,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -169,7 +169,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -128,7 +128,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -109,7 +109,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -68,7 +68,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -67,7 +67,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -86,7 +86,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -87,7 +87,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -97,7 +97,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -177,7 +177,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -129,7 +129,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -109,8 +109,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -142,7 +142,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -119,7 +119,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -348,7 +348,7 @@ private class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -133,7 +133,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -108,7 +108,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -100,7 +100,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -110,7 +110,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -98,7 +98,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -141,7 +141,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -154,7 +154,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -153,7 +153,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -191,7 +191,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -204,7 +204,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -190,7 +190,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -36,7 +36,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: RootState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -114,7 +114,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
@@ -40,7 +40,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Text(readMe)
 

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,13 +14,13 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
         .navigationViewStyle(.stack)
       }
       CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
         .navigationViewStyle(.stack)

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -94,7 +94,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -120,7 +120,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -99,7 +99,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -121,7 +121,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       VStack(alignment: .leading) {
         Picker(
           "Filter",

--- a/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0197-tca-concurrency-pt3/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -187,7 +187,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -157,7 +157,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -169,7 +169,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -128,7 +128,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -109,7 +109,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -68,7 +68,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -67,7 +67,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -86,7 +86,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -87,7 +87,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -97,7 +97,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -303,7 +303,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(count: 50_000),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -129,7 +129,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -109,8 +109,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -142,7 +142,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -119,7 +119,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -348,7 +348,7 @@ private class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -133,7 +133,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -108,7 +108,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -100,7 +100,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -110,7 +110,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -98,7 +98,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -141,7 +141,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -154,7 +154,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -153,7 +153,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -191,7 +191,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -204,7 +204,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -190,7 +190,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -36,7 +36,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: RootState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -114,7 +114,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
@@ -40,7 +40,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Text(readMe)
 

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,13 +14,13 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
         .navigationViewStyle(.stack)
       }
       CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
         .navigationViewStyle(.stack)

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -94,7 +94,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -120,7 +120,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -99,7 +99,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -121,7 +121,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       VStack(alignment: .leading) {
         Picker(
           "Filter",

--- a/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0198-tca-concurrency-pt4/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -187,7 +187,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -157,7 +157,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -169,7 +169,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -128,7 +128,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -109,7 +109,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -68,7 +68,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -67,7 +67,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -86,7 +86,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -87,7 +87,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -97,7 +97,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -318,7 +318,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(count: 50_000),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -129,7 +129,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -109,8 +109,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -142,7 +142,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -119,7 +119,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -348,7 +348,7 @@ private class WebSocketDelegate: NSObject, URLSessionWebSocketDelegate {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -133,7 +133,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -108,7 +108,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -100,7 +100,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -110,7 +110,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -98,7 +98,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -141,7 +141,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -154,7 +154,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -153,7 +153,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -191,7 +191,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -204,7 +204,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -190,7 +190,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/CaseStudiesApp.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct CaseStudiesApp: App {
   var body: some Scene {
     WindowGroup {
-//      NavigationView {
+//      NavigationStack {
 //        NavigationLink("Effect basics") {
 //          EffectsBasicsView(
 //            store: Store(

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -36,7 +36,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: RootState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -114,7 +114,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
@@ -40,7 +40,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Text(readMe)
 

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,13 +14,13 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
         .navigationViewStyle(.stack)
       }
       CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
         .navigationViewStyle(.stack)

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -94,7 +94,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -120,7 +120,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -99,7 +99,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -121,7 +121,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       VStack(alignment: .leading) {
         Picker(
           "Filter",

--- a/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0199-tca-concurrency-pt5/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -187,7 +187,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0202-reducer-protocol-pt2/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0202-reducer-protocol-pt2/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -143,7 +143,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -148,7 +148,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -160,7 +160,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -125,7 +125,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -110,7 +110,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -66,7 +66,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -77,7 +77,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -84,7 +84,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -86,7 +86,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -96,7 +96,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -161,7 +161,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -126,7 +126,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -103,8 +103,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -146,7 +146,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -115,7 +115,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -325,7 +325,7 @@ extension WebSocketClient {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -134,7 +134,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -109,7 +109,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -99,7 +99,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -111,7 +111,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -99,7 +99,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -135,7 +135,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -158,7 +158,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -154,7 +154,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -186,7 +186,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -199,7 +199,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -182,7 +182,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0203-reducer-protocol-pt3/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -140,7 +140,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -148,7 +148,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -160,7 +160,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -125,7 +125,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -110,7 +110,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -66,7 +66,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -77,7 +77,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -84,7 +84,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -86,7 +86,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -96,7 +96,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -161,7 +161,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -126,7 +126,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -103,8 +103,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -146,7 +146,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -115,7 +115,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -325,7 +325,7 @@ extension WebSocketClient {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -134,7 +134,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -109,7 +109,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -99,7 +99,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -111,7 +111,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -99,7 +99,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -135,7 +135,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -158,7 +158,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -154,7 +154,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -186,7 +186,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -199,7 +199,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -182,7 +182,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -36,7 +36,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: RootState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -120,7 +120,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
@@ -39,7 +39,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Text(readMe)
 

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,13 +14,13 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
         .navigationViewStyle(.stack)
       }
       CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
         .navigationViewStyle(.stack)

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -94,7 +94,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -120,7 +120,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -99,7 +99,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -125,7 +125,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       VStack(alignment: .leading) {
         Picker(
           "Filter",

--- a/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0204-reducer-protocol-pt4/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -141,7 +141,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -148,7 +148,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -160,7 +160,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -125,7 +125,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -110,7 +110,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -66,7 +66,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -77,7 +77,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -84,7 +84,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -86,7 +86,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -96,7 +96,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -161,7 +161,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -126,7 +126,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -103,8 +103,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -146,7 +146,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -115,7 +115,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -325,7 +325,7 @@ extension WebSocketClient {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -134,7 +134,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -109,7 +109,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -99,7 +99,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -111,7 +111,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -99,7 +99,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -135,7 +135,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -158,7 +158,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -154,7 +154,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -186,7 +186,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -199,7 +199,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -182,7 +182,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -36,7 +36,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: RootState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -120,7 +120,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
@@ -39,7 +39,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Text(readMe)
 

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,13 +14,13 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
         .navigationViewStyle(.stack)
       }
       CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
         .navigationViewStyle(.stack)

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -94,7 +94,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -120,7 +120,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -99,7 +99,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -125,7 +125,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       VStack(alignment: .leading) {
         Picker(
           "Filter",

--- a/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0205-reducer-protocol-pt5/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -146,7 +146,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -148,7 +148,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -160,7 +160,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -125,7 +125,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -110,7 +110,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -66,7 +66,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -77,7 +77,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -84,7 +84,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -86,7 +86,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -96,7 +96,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -161,7 +161,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -126,7 +126,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -103,8 +103,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -146,7 +146,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -115,7 +115,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -325,7 +325,7 @@ extension WebSocketClient {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -134,7 +134,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -109,7 +109,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -99,7 +99,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -111,7 +111,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -99,7 +99,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -135,7 +135,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -158,7 +158,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -154,7 +154,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -186,7 +186,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -199,7 +199,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -182,7 +182,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -36,7 +36,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: RootState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -120,7 +120,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
@@ -39,7 +39,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Text(readMe)
 

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,13 +14,13 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
         .navigationViewStyle(.stack)
       }
       CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
         .navigationViewStyle(.stack)

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -94,7 +94,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -120,7 +120,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -99,7 +99,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -125,7 +125,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       VStack(alignment: .leading) {
         Picker(
           "Filter",

--- a/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0206-reducer-protocol-pt6/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -146,7 +146,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/00-RootView.swift
@@ -7,7 +7,7 @@ struct RootView: View {
 
   var body: some View {
     WithViewStore(self.store.stateless) { viewStore in
-      NavigationView {
+      NavigationStack {
         Form {
           Section(header: Text("Getting started")) {
             NavigationLink(

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-AlertsAndConfirmationDialogs.swift
@@ -112,7 +112,7 @@ struct AlertAndConfirmationDialogView: View {
 
 struct AlertAndConfirmationDialog_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       AlertAndConfirmationDialogView(
         store: Store(
           initialState: AlertAndConfirmationDialogState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Animations.swift
@@ -148,7 +148,7 @@ struct AnimationsView: View {
 struct AnimationsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),
@@ -160,7 +160,7 @@ struct AnimationsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         AnimationsView(
           store: Store(
             initialState: AnimationsState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Basics.swift
@@ -125,7 +125,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingBasicsView(
         store: Store(
           initialState: BindingBasicsState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Bindings-Forms.swift
@@ -110,7 +110,7 @@ private func alternate(_ string: String) -> String {
 
 struct BindingFormView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       BindingFormView(
         store: Store(
           initialState: BindingFormState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Composition-TwoCounters.swift
@@ -66,7 +66,7 @@ struct TwoCountersView: View {
 
 struct TwoCountersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoCountersView(
         store: Store(
           initialState: TwoCountersState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-Counter.swift
@@ -77,7 +77,7 @@ struct CounterDemoView: View {
 
 struct CounterView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       CounterDemoView(
         store: Store(
           initialState: CounterState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-FocusState.swift
@@ -84,7 +84,7 @@ extension View {
 
 struct FocusDemo_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       FocusDemoView(
         store: Store(
           initialState: FocusDemoState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/01-GettingStarted-OptionalState.swift
@@ -86,7 +86,7 @@ struct OptionalBasicsView: View {
 struct OptionalBasicsView_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(),
@@ -96,7 +96,7 @@ struct OptionalBasicsView_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         OptionalBasicsView(
           store: Store(
             initialState: OptionalBasicsState(optionalCounter: CounterState(count: 42)),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Basics.swift
@@ -161,7 +161,7 @@ struct EffectsBasicsView: View {
 
 struct EffectsBasicsView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsBasicsView(
         store: Store(
           initialState: EffectsBasicsState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Cancellation.swift
@@ -126,7 +126,7 @@ struct EffectsCancellationView: View {
 
 struct EffectsCancellation_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EffectsCancellationView(
         store: Store(
           initialState: EffectsCancellationState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-LongLiving.swift
@@ -103,8 +103,8 @@ struct EffectsLongLiving_Previews: PreviewProvider {
     )
 
     return Group {
-      NavigationView { appView }
-      NavigationView { appView.detailView }
+      NavigationStack { appView }
+      NavigationStack { appView.detailView }
     }
   }
 }

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-SystemEnvironment.swift
@@ -146,7 +146,7 @@ struct MultipleDependenciesView: View {
 
 struct MultipleDependenciesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       MultipleDependenciesView(
         store: Store(
           initialState: MultipleDependenciesState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-Timers.swift
@@ -115,7 +115,7 @@ struct TimersView: View {
 
 struct TimersView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TimersView(
         store: Store(
           initialState: TimersState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/02-Effects-WebSocket.swift
@@ -325,7 +325,7 @@ extension WebSocketClient {
 
 struct WebSocketView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       WebSocketView(
         store: Store(
           initialState: WebSocketState(receivedMessages: ["Echo"]),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-LoadThenNavigate.swift
@@ -134,7 +134,7 @@ struct LoadThenNavigateListView: View {
 
 struct LoadThenNavigateListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateListView(
         store: Store(
           initialState: LoadThenNavigateListState(

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Lists-NavigateAndLoad.swift
@@ -114,7 +114,7 @@ struct NavigateAndLoadListView: View {
 
 struct NavigateAndLoadListView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadListView(
         store: Store(
           initialState: NavigateAndLoadListState(

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-LoadThenNavigate.swift
@@ -109,7 +109,7 @@ struct LoadThenNavigateView: View {
 
 struct LoadThenNavigateView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenNavigateView(
         store: Store(
           initialState: LoadThenNavigateState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-NavigateAndLoad.swift
@@ -99,7 +99,7 @@ struct NavigateAndLoadView: View {
 
 struct NavigateAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NavigateAndLoadView(
         store: Store(
           initialState: NavigateAndLoadState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-LoadThenPresent.swift
@@ -111,7 +111,7 @@ struct LoadThenPresentView: View {
 
 struct LoadThenPresentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoadThenPresentView(
         store: Store(
           initialState: LoadThenPresentState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-Navigation-Sheet-PresentAndLoad.swift
@@ -99,7 +99,7 @@ struct PresentAndLoadView: View {
 
 struct PresentAndLoadView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       PresentAndLoadView(
         store: Store(
           initialState: PresentAndLoadState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ElmLikeSubscriptions.swift
@@ -135,7 +135,7 @@ struct ClockView: View {
 
 struct Subscriptions_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ClockView(
         store: Store(
           initialState: ClockState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Lifecycle.swift
@@ -158,7 +158,7 @@ private struct TimerView: View {
 struct Lifecycle_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         LifecycleDemoView(
           store: Store(
             initialState: LifecycleDemoState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-Recursion.swift
@@ -154,7 +154,7 @@ extension NestedState {
 #if DEBUG
   struct NestedView_Previews: PreviewProvider {
     static var previews: some View {
-      NavigationView {
+      NavigationStack {
         NestedView(
           store: Store(
             initialState: .mock,

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ResuableOfflineDownloads/ReusableComponents-Download.swift
@@ -186,7 +186,7 @@ struct CitiesView: View {
 struct DownloadList_Previews: PreviewProvider {
   static var previews: some View {
     Group {
-      NavigationView {
+      NavigationStack {
         CitiesView(
           store: Store(
             initialState: MapAppState(cityMaps: .mocks),
@@ -199,7 +199,7 @@ struct DownloadList_Previews: PreviewProvider {
         )
       }
 
-      NavigationView {
+      NavigationStack {
         CityMapDetailView(
           store: Store(
             initialState: IdentifiedArray.mocks.first!,

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/04-HigherOrderReducers-ReusableFavoriting.swift
@@ -182,7 +182,7 @@ struct EpisodesView: View {
 
 struct EpisodesView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       EpisodesView(
         store: Store(
           initialState: EpisodesState(

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/CaseStudies/tvOSCaseStudies/RootView.swift
@@ -5,7 +5,7 @@ struct RootView: View {
   let store: Store<RootState, RootAction>
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Section {
           self.focusView
@@ -36,7 +36,7 @@ struct RootView: View {
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       RootView(
         store: Store(
           initialState: RootState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/Search/Search/SearchView.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/Search/Search/SearchView.swift
@@ -120,7 +120,7 @@ struct SearchView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack(alignment: .leading) {
           Text(readMe)
             .padding()

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/App/RootView.swift
@@ -39,7 +39,7 @@ struct RootView: View {
   @State var showGame: GameType?
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       Form {
         Text(readMe)
 

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/AppSwiftUI/AppView.swift
@@ -14,13 +14,13 @@ public struct AppView: View {
   public var body: some View {
     SwitchStore(self.store) {
       CaseLet(state: /AppState.login, action: AppAction.login) { store in
-        NavigationView {
+        NavigationStack {
           LoginView(store: store)
         }
         .navigationViewStyle(.stack)
       }
       CaseLet(state: /AppState.newGame, action: AppAction.newGame) { store in
-        NavigationView {
+        NavigationStack {
           NewGameView(store: store)
         }
         .navigationViewStyle(.stack)

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/GameSwiftUI/GameView.swift
@@ -94,7 +94,7 @@ public struct GameView: View {
 
 struct Game_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       GameView(
         store: Store(
           initialState: GameState(oPlayerName: "Blob Jr.", xPlayerName: "Blob Sr."),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/LoginSwiftUI/LoginView.swift
@@ -120,7 +120,7 @@ extension LoginAction {
 
 struct LoginView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       LoginView(
         store: Store(
           initialState: LoginState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/NewGameSwiftUI/NewGameView.swift
@@ -99,7 +99,7 @@ extension NewGameAction {
 
 struct NewGame_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       NewGameView(
         store: Store(
           initialState: NewGameState(),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/TicTacToe/tic-tac-toe/Sources/TwoFactorSwiftUI/TwoFactorView.swift
@@ -88,7 +88,7 @@ extension TwoFactorAction {
 
 struct TwoFactorView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       TwoFactorView(
         store: Store(
           initialState: TwoFactorState(token: "deadbeef"),

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/Todos/Todos/Todos.swift
@@ -125,7 +125,7 @@ struct AppView: View {
   }
 
   var body: some View {
-    NavigationView {
+    NavigationStack {
       VStack(alignment: .leading) {
         Picker(
           "Filter",

--- a/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
+++ b/0207-reducer-protocol-pt7/swift-composable-architecture/Examples/VoiceMemos/VoiceMemos/VoiceMemos.swift
@@ -146,7 +146,7 @@ struct VoiceMemosView: View {
 
   var body: some View {
     WithViewStore(self.store) { viewStore in
-      NavigationView {
+      NavigationStack {
         VStack {
           List {
             ForEachStore(

--- a/0211-navigation-stacks-pt1/Inventory/Inventory/ItemRowPreviewApp/ItemRowPreviewAppApp.swift
+++ b/0211-navigation-stacks-pt1/Inventory/Inventory/ItemRowPreviewApp/ItemRowPreviewAppApp.swift
@@ -14,7 +14,7 @@ struct ItemRowPreviewAppApp: App {
 
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
         List {
           ItemRowView(model: self.model)
         }

--- a/0211-navigation-stacks-pt1/Inventory/Sources/InventoryFeature/Inventory.swift
+++ b/0211-navigation-stacks-pt1/Inventory/Sources/InventoryFeature/Inventory.swift
@@ -71,7 +71,7 @@ public struct InventoryView: View {
   }
 
   public var body: some View {
-    NavigationView {
+    NavigationStack {
       List {
         ForEach(
           self.model.inventory,
@@ -97,7 +97,7 @@ public struct InventoryView: View {
         unwrapping: self.$model.destination,
         case: CasePath(InventoryModel.Destination.add)
       ) { $itemToAdd in
-        NavigationView {
+        NavigationStack {
           ItemView(model: itemToAdd)
             .navigationTitle("Add")
             .toolbar {
@@ -118,7 +118,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
 
-    NavigationView {
+    NavigationStack {
       InventoryView(
         model: InventoryModel(
           inventory: [

--- a/0211-navigation-stacks-pt1/Inventory/Sources/ItemFeature/ItemView.swift
+++ b/0211-navigation-stacks-pt1/Inventory/Sources/ItemFeature/ItemView.swift
@@ -91,7 +91,7 @@ public struct ItemView: View {
 
 struct ItemView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ItemView(
         model: ItemModel(
           item: Item(name: "", color: nil, status: .inStock(quantity: 1))

--- a/0211-navigation-stacks-pt1/Inventory/Sources/ItemRowFeature/ItemRow.swift
+++ b/0211-navigation-stacks-pt1/Inventory/Sources/ItemRowFeature/ItemRow.swift
@@ -176,7 +176,7 @@ public struct ItemRowView: View {
       unwrapping: self.$model.destination,
       case: /ItemRowModel.Destination.duplicate
     ) { $itemModel in
-      NavigationView {
+      NavigationStack {
         ItemView(model: itemModel)
           .navigationBarTitle("Duplicate")
           .toolbar {
@@ -199,7 +199,7 @@ public struct ItemRowView: View {
 
 struct ItemRowPreviews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       List {
         ItemRowView(
           model: ItemRowModel(

--- a/0212-navigation-stacks-pt2/Inventory/Inventory/ItemRowPreviewApp/ItemRowPreviewAppApp.swift
+++ b/0212-navigation-stacks-pt2/Inventory/Inventory/ItemRowPreviewApp/ItemRowPreviewAppApp.swift
@@ -14,7 +14,7 @@ struct ItemRowPreviewAppApp: App {
 
   var body: some Scene {
     WindowGroup {
-      NavigationView {
+      NavigationStack {
         List {
           ItemRowView(model: self.model)
         }

--- a/0212-navigation-stacks-pt2/Inventory/Sources/InventoryFeature/Inventory.swift
+++ b/0212-navigation-stacks-pt2/Inventory/Sources/InventoryFeature/Inventory.swift
@@ -188,7 +188,7 @@ public struct InventoryView: View {
         unwrapping: self.$model.destination,
         case: CasePath(InventoryModel.Destination.add)
       ) { $itemToAdd in
-        NavigationView {
+        NavigationStack {
           ItemView(model: itemToAdd)
             .navigationTitle("Add")
             .toolbar {
@@ -209,7 +209,7 @@ struct InventoryView_Previews: PreviewProvider {
   static var previews: some View {
     let keyboard = Item(name: "Keyboard", color: .blue, status: .inStock(quantity: 100))
 
-    NavigationView {
+    NavigationStack {
       InventoryView(
         model: InventoryModel(
           inventory: [

--- a/0212-navigation-stacks-pt2/Inventory/Sources/ItemFeature/ItemView.swift
+++ b/0212-navigation-stacks-pt2/Inventory/Sources/ItemFeature/ItemView.swift
@@ -92,7 +92,7 @@ public struct ItemView: View {
 
 struct ItemView_Previews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       ItemView(
         model: ItemModel(
           item: Item(name: "", color: nil, status: .inStock(quantity: 1))

--- a/0212-navigation-stacks-pt2/Inventory/Sources/ItemRowFeature/ItemRow.swift
+++ b/0212-navigation-stacks-pt2/Inventory/Sources/ItemRowFeature/ItemRow.swift
@@ -184,7 +184,7 @@ public struct ItemRowView: View {
       unwrapping: self.$model.destination,
       case: /ItemRowModel.Destination.duplicate
     ) { $itemModel in
-      NavigationView {
+      NavigationStack {
         ItemView(model: itemModel)
           .navigationBarTitle("Duplicate")
           .toolbar {
@@ -207,7 +207,7 @@ public struct ItemRowView: View {
 
 struct ItemRowPreviews: PreviewProvider {
   static var previews: some View {
-    NavigationView {
+    NavigationStack {
       List {
         ItemRowView(
           model: ItemRowModel(


### PR DESCRIPTION
Hi!

Thank you so much for sharing your code and for the interesting videos. I've already started watching them and I'm getting exited about your composable architecture.

On Xcode Version 14.2 in Playground `NavigationView` is being rendered as split view. This behavior doesn't seem that is going to be fixed, since in the next version of the different Apple OSs (iOS 16.4, iPadOS 16.4, macOS 13.3, Mac Catalyst 16.4, tvOS 16.4 and watchOS 9.4) [`NavigationView` will be deprecated](https://developer.apple.com/documentation/swiftui/navigationview). 

![exercise_split_view](https://user-images.githubusercontent.com/38757307/224574174-ef5102cd-30f6-42c5-a739-8f3f2794d46a.png)

In order to replace the appearance of the exercises shown in the videos, I replaced here the usages of `NavigationView` with `NavigationStack`.
