### PR TITLE
Fix a build error in the 70th episode example code

### DIFF
--- a/0070-composable-state-management-action-pullbacks/ComposableArchitecture.playground/Contents.swift
+++ b/0070-composable-state-management-action-pullbacks/ComposableArchitecture.playground/Contents.swift
@@ -374,6 +374,6 @@ struct ContentView: View {
 import PlaygroundSupport
 PlaygroundPage.current.liveView = UIHostingController(
   rootView: ContentView(
-    store: Store(initialValue: AppState(), appReducer)
+    store: Store(initialValue: AppState(), reducer: appReducer)
   )
 )


### PR DESCRIPTION
Added the missing argument `reducer` in `Store`'s initializer 🙂 