### PR TITLE
fix/public-access-modifier-episode73

### DIFF
--- a/0073-modular-state-management-view-state/PrimeTime/ComposableArchitecture/ComposableArchitecture.swift
+++ b/0073-modular-state-management-view-state/PrimeTime/ComposableArchitecture/ComposableArchitecture.swift
@@ -19,7 +19,7 @@ public final class Store<Value, Action>: ObservableObject {
   // ((A) -> B) -> ((Store<A, _>) -> Store<B, _>
   // map: ((A) -> B) -> ((F<A>) -> F<B>
 
-  func view<LocalValue>(
+  public func view<LocalValue>(
     _ f: @escaping (Value) -> LocalValue
   ) -> Store<LocalValue, Action> {
     let localStore = Store<LocalValue, Action>(


### PR DESCRIPTION
Fix the access modifier in the example code from episode 73 of ComposableArchitecture.

The following function should be declared as public:

```
func view<LocalValue>(
  _ f: @escaping (Value) -> LocalValue
) -> Store<LocalValue, Action> {
  let localStore = Store<LocalValue, Action>(
    initialValue: f(self.value),
    reducer: { localValue, action in
      self.send(action)
      localValue = f(self.value)
    }
  )
  localStore.cancellable = self.$value.sink { [weak localStore] newValue in
    localStore?.value = f(newValue)
  }
  return localStore
}
```

I fixed the build error by declaring this function as public.